### PR TITLE
Add verbose debug logging and socket safety check

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ go build ./cmd/grimux
 ./grimux -capture <pane-id>
 ```
 If `<pane-id>` is omitted, the current pane is captured.
+Pass `-verbose` to see detailed tmux communication logs.
 
 ## Finding pane IDs 🆔
 You can discover the ID of each pane with `tmux list-panes -F '#{pane_id} #{pane_title}'`. The `#{pane_id}` values (like `%1`, `%2` ...) can then be passed to `-capture`.
@@ -42,3 +43,9 @@ tmux list-panes -F '#{pane_id} #{pane_current_command}'
 ./grimux -capture %1
 ```
    You should see the contents displayed in the `grimux` pane.
+
+## Running tests 🧪
+Unit tests can be executed with:
+```bash
+go test ./...
+```

--- a/cmd/grimux/main.go
+++ b/cmd/grimux/main.go
@@ -10,7 +10,10 @@ import (
 
 func main() {
 	target := flag.String("capture", "", "tmux pane to capture")
+	verbose := flag.Bool("verbose", false, "enable verbose logging")
 	flag.Parse()
+
+	tmux.Verbose = *verbose
 
 	if *target != "" {
 		content, err := tmux.CapturePane(*target)

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -5,10 +5,20 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"strings"
 )
+
+// Verbose controls whether debug logging is enabled.
+var Verbose bool
+
+func debugf(format string, args ...interface{}) {
+	if Verbose {
+		log.Printf(format, args...)
+	}
+}
 
 // CapturePane connects to the tmux server over its UNIX socket and captures the
 // contents of the specified pane. If target is empty, the current pane is
@@ -20,17 +30,23 @@ func CapturePane(target string) (string, error) {
 	}
 
 	socket := strings.Split(tmuxEnv, ",")[0]
+	debugf("using tmux socket: %s", socket)
+	if _, err := os.Stat(socket); err != nil {
+		return "", fmt.Errorf("tmux socket missing: %w", err)
+	}
+
 	conn, err := net.Dial("unix", socket)
 	if err != nil {
 		return "", fmt.Errorf("connect tmux socket: %w", err)
 	}
 	defer conn.Close()
 
-	if target == "" {
-		target = "" // current pane
+	cmd := "capture-pane -p"
+	if target != "" {
+		cmd += " -t " + target
 	}
-
-	cmd := fmt.Sprintf("capture-pane -p -t %s\n", target)
+	cmd += "\n"
+	debugf("sending command: %s", strings.TrimSpace(cmd))
 	if _, err := conn.Write([]byte(cmd)); err != nil {
 		return "", fmt.Errorf("write command: %w", err)
 	}
@@ -45,14 +61,17 @@ func CapturePane(target string) (string, error) {
 			parsing = true
 			continue
 		case strings.HasPrefix(line, "%end"):
+			debugf("capture complete")
 			return buf.String(), nil
 		}
 		if parsing {
+			debugf("recv: %s", line)
 			buf.WriteString(line)
 			buf.WriteByte('\n')
 		}
 	}
 	if err := scanner.Err(); err != nil {
+		debugf("scan error: %v", err)
 		return "", err
 	}
 	return "", errors.New("unexpected end of stream")

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -1,0 +1,70 @@
+package tmux
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func startFakeTmux(t *testing.T, expected string, lines []string) (string, func()) {
+	t.Helper()
+	tmp := t.TempDir()
+	sock := filepath.Join(tmp, "tmux.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		r := bufio.NewReader(conn)
+		cmd, _ := r.ReadString('\n')
+		if cmd != expected {
+			t.Errorf("unexpected command: %q", cmd)
+		}
+		for _, line := range lines {
+			fmt.Fprintln(conn, line)
+		}
+	}()
+	cleanup := func() {
+		ln.Close()
+		<-done
+	}
+	return sock, cleanup
+}
+
+func TestCapturePaneWithTarget(t *testing.T) {
+	expected := "capture-pane -p -t %1\n"
+	sock, cleanup := startFakeTmux(t, expected, []string{"%begin", "hello", "%end"})
+	defer cleanup()
+	os.Setenv("TMUX", sock+",session")
+	got, err := CapturePane("%1")
+	if err != nil {
+		t.Fatalf("CapturePane: %v", err)
+	}
+	if got != "hello\n" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestCapturePaneCurrent(t *testing.T) {
+	expected := "capture-pane -p\n"
+	sock, cleanup := startFakeTmux(t, expected, []string{"%begin", "hi", "%end"})
+	defer cleanup()
+	os.Setenv("TMUX", sock+",session")
+	got, err := CapturePane("")
+	if err != nil {
+		t.Fatalf("CapturePane: %v", err)
+	}
+	if got != "hi\n" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add `-verbose` flag to enable debug logs
- implement verbose logging in `tmux` package
- verify tmux socket exists before dialing
- document verbose option in README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843a50f5c0083298fde44b087f9220d