### PR TITLE
Implement pane reference replacement in REPL

### DIFF
--- a/internal/repl/repl_test.go
+++ b/internal/repl/repl_test.go
@@ -1,0 +1,36 @@
+package repl
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestReplacePaneRefs(t *testing.T) {
+	old := capturePane
+	capturePane = func(target string) (string, error) {
+		if target != "%1" {
+			return "", errors.New("bad target")
+		}
+		return "hello\n", nil
+	}
+	defer func() { capturePane = old }()
+
+	got := replacePaneRefs("before /{%1}/ after")
+	expected := "before ```\nhello\n``` after"
+	if got != expected {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestReplacePaneRefsError(t *testing.T) {
+	old := capturePane
+	capturePane = func(target string) (string, error) {
+		return "", errors.New("fail")
+	}
+	defer func() { capturePane = old }()
+
+	got := replacePaneRefs("/{%2}/")
+	if got != "[capture error: fail]" {
+		t.Fatalf("unexpected error output: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add parsing for `/{%d}/` syntax in REPL
- insert captured pane text as fenced code blocks
- test new replacement logic

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843b43155b48329b3821d5f0fa98d67