### PR TITLE
Add colorful startup and Ctrl-D exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A tmux-driven AI-assisted rapid prototyping interface
 ## About 🚀
 `grimux` is a small proof-of-concept that shows how a Go CLI can talk to tmux directly. The long term idea is to build a TUI that can capture pane contents, send them to an AI backend and display the results in another pane. For now the tool just demonstrates how to capture text from another pane via tmux's UNIX socket.
 
+When launched with no arguments the CLI now prints colorful ASCII art and asks the OpenAI API for a random, pithy complaint about dealing with nonsense. The prompt as well as the command prompt itself are decorated with a bit of color and emoji flair.
+
 ## Building 🔧
 ```bash
 go build ./cmd/grimux


### PR DESCRIPTION
## Summary
- display colorful ASCII art on startup and query OpenAI for a short complaint
- colorize the REPL prompt with an emoji
- handle Ctrl-D to quit
- document new behavior in the README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6843c00143888329b68130baa1a622e4