### PR TITLE
Add buffers and file management to REPL

### DIFF
--- a/internal/repl/repl_test.go
+++ b/internal/repl/repl_test.go
@@ -34,3 +34,20 @@ func TestReplacePaneRefsError(t *testing.T) {
 		t.Fatalf("unexpected error output: %q", got)
 	}
 }
+
+func TestReplaceBufferRefs(t *testing.T) {
+	buffers["%foo"] = "bar"
+	defer func() { delete(buffers, "%foo") }()
+	got := replaceBufferRefs("hello %foo world")
+	if got != "hello bar world" {
+		t.Fatalf("unexpected buffer replace: %q", got)
+	}
+}
+
+func TestLastCodeBlock(t *testing.T) {
+	text := "``go\nfirst\n```\ntext\n```python\nsecond\n```"
+	code := lastCodeBlock(text)
+	if code != "second" {
+		t.Fatalf("unexpected last code block: %q", code)
+	}
+}


### PR DESCRIPTION
## Summary
- support `%file` and `%code` buffers
- add `!save`, `!file`, `!edit`, `!run`, and `!var` commands
- autocompletion for new commands and filepath arguments
- capture last code block returned from `!ask`
- tests for buffer replacement and code parsing

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843cca686b4832991aa44290a9a2d75