### PR TITLE
Enhance grimux REPL

### DIFF
--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -3,6 +3,7 @@ package repl
 import (
 	"bufio"
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
@@ -41,6 +42,24 @@ var buffers = map[string]string{
 	"%file": "",
 	"%code": "",
 }
+
+var history []string
+
+const sessionFile = ".grimux_session"
+
+var askPrefix = "You are a offensive security co-pilot, please answer the following prompt with high technical accuracy from a pentesting angle. Please response to the following prompt using hacker lingo and use pithy markdown with liberal emojis: "
+
+type session struct {
+	History []string          `json:"history"`
+	Buffers map[string]string `json:"buffers"`
+	Prompt  string            `json:"prompt"`
+}
+
+const grimColor = "\033[38;5;141m"
+
+func colorize(s string) string { return grimColor + s + "\033[0m" }
+func cprintln(s string)        { fmt.Println(colorize(s)) }
+func cprint(s string)          { fmt.Print(colorize(s)) }
 
 func replacePaneRefs(text string) string {
 	return panePattern.ReplaceAllStringFunc(text, func(tok string) string {
@@ -108,17 +127,27 @@ func Run() error {
 	defer stopRaw(oldState)
 
 	reader := bufio.NewReader(os.Stdin)
-	history := []string{}
+	history = []string{}
+	if b, err := os.ReadFile(sessionFile); err == nil {
+		var s session
+		if json.Unmarshal(b, &s) == nil {
+			history = s.History
+			buffers = s.Buffers
+			if s.Prompt != "" {
+				askPrefix = s.Prompt
+			}
+		}
+	}
 	histIdx := 0
 	lineBuf := bytes.Buffer{}
 
-	fmt.Println(asciiArt + "\nWelcome to grimux! 💀")
+	cprintln(asciiArt + "\nWelcome to grimux! 💀")
 
 	rand.Seed(time.Now().UnixNano())
 	if client, err := openai.NewClient(); err == nil {
 		p := prompts[rand.Intn(len(prompts))]
 		if reply, err := client.SendPrompt(p); err == nil {
-			fmt.Println(reply)
+			cprintln(reply)
 		}
 	}
 
@@ -151,14 +180,14 @@ func Run() error {
 					return
 				}
 				if len(matches) > 1 {
-					fmt.Println()
-					fmt.Println(strings.Join(matches, "  "))
+					cprintln("")
+					cprintln(strings.Join(matches, "  "))
 					printLine()
 					return
 				}
 			}
 		}
-		cmds := []string{"!capture", "!list", "!quit", "!ask", "!save", "!var", "!file", "!edit", "!run"}
+		cmds := []string{"!capture", "!list", "!quit", "!exit", "!ask", "!save", "!var", "!varcode", "!file", "!edit", "!run", "!print", "!prompt", "!set_prompt", "!get_prompt", "!run_on"}
 		matches := []string{}
 		for _, c := range cmds {
 			if strings.HasPrefix(c, prefix) {
@@ -174,8 +203,8 @@ func Run() error {
 			printLine()
 			return
 		}
-		fmt.Println()
-		fmt.Println(strings.Join(matches, "  "))
+		cprintln("")
+		cprintln(strings.Join(matches, "  "))
 		printLine()
 	}
 
@@ -194,7 +223,8 @@ func Run() error {
 		}
 		for i := len(history) - 1; i >= 0; i-- {
 			if strings.Contains(history[i], query) {
-				fmt.Printf("\n%s\n", history[i])
+				cprint("\n")
+				cprintln(history[i])
 				lineBuf.Reset()
 				lineBuf.WriteString(history[i])
 				histIdx = i
@@ -214,7 +244,7 @@ func Run() error {
 		case '\n', '\r':
 			line := lineBuf.String()
 			lineBuf.Reset()
-			fmt.Println()
+			cprintln("")
 			if len(line) == 0 {
 				prompt()
 				continue
@@ -233,14 +263,14 @@ func Run() error {
 			} else {
 				client, err := openai.NewClient()
 				if err != nil {
-					fmt.Println(err)
+					cprintln(err.Error())
 				} else {
 					promptText := replaceBufferRefs(replacePaneRefs(line))
 					reply, err := client.SendPrompt(promptText)
 					if err != nil {
-						fmt.Println("openai error:", err)
+						cprintln("openai error: " + err.Error())
 					} else {
-						fmt.Println(reply)
+						cprintln(reply)
 						buffers["%code"] = lastCodeBlock(reply)
 					}
 				}
@@ -252,10 +282,10 @@ func Run() error {
 			clearScreen()
 			prompt()
 		case 3: // Ctrl+C
-			fmt.Println()
+			cprintln("")
 			return nil
 		case 4: // Ctrl+D
-			fmt.Println()
+			cprintln("")
 			return nil
 		case 127: // Backspace
 			if lineBuf.Len() > 0 {
@@ -268,10 +298,16 @@ func Run() error {
 			autocomplete()
 		case 18: // Ctrl+R reverse search
 			reverseSearch()
-		case 27: // escape sequences (arrows)
+		case 27: // escape sequences (arrows or alt-digit)
 			next1, _, err := reader.ReadRune()
 			if err != nil {
 				return err
+			}
+			if next1 >= '0' && next1 <= '9' {
+				token := fmt.Sprintf("{%%%c}", next1)
+				lineBuf.WriteString(token)
+				cprint(token)
+				continue
 			}
 			if next1 != '[' {
 				continue
@@ -302,82 +338,100 @@ func Run() error {
 			}
 		default:
 			lineBuf.WriteRune(r)
-			fmt.Printf("%c", r)
+			cprint(string(r))
 		}
 	}
 }
 
 // handleCommand executes a ! command. Returns true if repl should quit.
+func saveSession() {
+	s := session{History: history, Buffers: buffers, Prompt: askPrefix}
+	if b, err := json.MarshalIndent(s, "", "  "); err == nil {
+		os.WriteFile(sessionFile, b, 0644)
+	}
+}
+
 func handleCommand(cmd string) bool {
 	fields := strings.Fields(cmd)
 	switch fields[0] {
-	case "!quit", "!exit":
+	case "!quit":
+		saveSession()
+		return true
+	case "!exit":
 		return true
 	case "!list":
-		c := exec.Command("tmux", "list-panes", "-F", "#{pane_id} #{pane_title}")
+		c := exec.Command("tmux", "list-panes", "-F", "#{pane_id} #{pane_title} #{pane_current_command}")
 		c.Stdout = os.Stdout
 		c.Run()
+		for k, v := range buffers {
+			cprintln(fmt.Sprintf("%s (%d bytes)", k, len(v)))
+		}
 	case "!capture":
-		if len(fields) < 2 {
-			fmt.Println("usage: !capture <pane-id>")
+		if len(fields) < 3 {
+			cprintln("usage: !capture <buffer> <pane-id>")
 			return false
 		}
-		out, err := exec.Command(os.Args[0], "-capture", fields[1]).Output()
+		out, err := exec.Command(os.Args[0], "-capture", fields[2]).Output()
 		if err != nil {
-			fmt.Println("capture error:", err)
+			cprintln("capture error: " + err.Error())
 			return false
 		}
-		fmt.Print(string(out))
+		buffers[fields[1]] = string(out)
+		cprint(string(out))
 	case "!save":
 		if len(fields) < 3 {
-			fmt.Println("usage: !save <buffer> <file>")
+			cprintln("usage: !save <buffer> <file>")
 			return false
 		}
 		data, ok := buffers[fields[1]]
 		if !ok {
-			fmt.Println("unknown buffer")
+			cprintln("unknown buffer")
 			return false
 		}
 		if err := os.WriteFile(fields[2], []byte(data), 0644); err != nil {
-			fmt.Println("save error:", err)
+			cprintln("save error: " + err.Error())
 		}
 	case "!file":
 		if len(fields) < 2 {
-			fmt.Println("usage: !file <path>")
+			cprintln("usage: !file <path>")
 			return false
 		}
 		b, err := os.ReadFile(fields[1])
 		if err != nil {
-			fmt.Println("file error:", err)
+			cprintln("file error: " + err.Error())
 			return false
 		}
 		buffers["%file"] = string(b)
 	case "!edit":
 		if len(fields) < 2 {
-			fmt.Println("usage: !edit <buffer>")
+			cprintln("usage: !edit <buffer>")
 			return false
 		}
 		data, ok := buffers[fields[1]]
 		if !ok {
-			fmt.Println("unknown buffer")
+			cprintln("unknown buffer")
 			return false
 		}
 		tmp, err := os.CreateTemp("", "grimux-edit-*.tmp")
 		if err != nil {
-			fmt.Println("tempfile error:", err)
+			cprintln("tempfile error: " + err.Error())
 			return false
 		}
 		if _, err := tmp.WriteString(data); err != nil {
-			fmt.Println("write temp error:", err)
+			cprintln("write temp error: " + err.Error())
 			return false
 		}
 		tmp.Close()
-		cmd := exec.Command("vim", tmp.Name())
+		editor := os.Getenv("EDITOR")
+		if editor == "" {
+			editor = "vim"
+		}
+		cmd := exec.Command(editor, tmp.Name())
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
-			fmt.Println("vim error:", err)
+			cprintln("vim error: " + err.Error())
 		}
 		if b, err := os.ReadFile(tmp.Name()); err == nil {
 			buffers[fields[1]] = string(b)
@@ -385,62 +439,122 @@ func handleCommand(cmd string) bool {
 		os.Remove(tmp.Name())
 	case "!run":
 		if len(fields) < 2 {
-			fmt.Println("usage: !run <command>")
+			cprintln("usage: !run <command>")
 			return false
 		}
 		cmdStr := replaceBufferRefs(strings.Join(fields[1:], " "))
-		c := exec.Command("sh", "-c", cmdStr)
+		c := exec.Command("bash", "-c", cmdStr)
 		var out bytes.Buffer
 		c.Stdout = &out
 		c.Stderr = &out
 		if err := c.Run(); err != nil {
-			fmt.Println("run error:", err)
+			cprintln("run error: " + err.Error())
 		}
-		fmt.Print(out.String())
+		cprint(out.String())
 	case "!var":
 		if len(fields) < 3 {
-			fmt.Println("usage: !var <buffer> <prompt>")
+			cprintln("usage: !var <buffer> <prompt>")
 			return false
 		}
 		client, err := openai.NewClient()
 		if err != nil {
-			fmt.Println(err)
+			cprintln(err.Error())
 			return false
 		}
 		promptText := replaceBufferRefs(replacePaneRefs(strings.Join(fields[2:], " ")))
 		reply, err := client.SendPrompt(promptText)
 		if err != nil {
-			fmt.Println("openai error:", err)
+			cprintln("openai error: " + err.Error())
 			return false
 		}
-		buffers[fields[1]] = lastCodeBlock(reply)
-		fmt.Println(reply)
-	case "!ask":
-		if len(fields) < 2 {
-			fmt.Println("usage: !ask <prompt>")
+		buffers[fields[1]] = reply
+		cprintln(reply)
+	case "!varcode":
+		if len(fields) < 3 {
+			cprintln("usage: !varcode <buffer> <prompt>")
 			return false
 		}
 		client, err := openai.NewClient()
 		if err != nil {
-			fmt.Println(err)
+			cprintln(err.Error())
+			return false
+		}
+		promptText := replaceBufferRefs(replacePaneRefs(strings.Join(fields[2:], " ")))
+		reply, err := client.SendPrompt(promptText)
+		if err != nil {
+			cprintln("openai error: " + err.Error())
+			return false
+		}
+		buffers[fields[1]] = lastCodeBlock(reply)
+		cprintln(reply)
+	case "!print":
+		if len(fields) < 2 {
+			cprintln("usage: !print <buffer>")
+			return false
+		}
+		cprint(buffers[fields[1]])
+	case "!prompt":
+		if len(fields) < 3 {
+			cprintln("usage: !prompt <buffer> <text>")
+			return false
+		}
+		buffers[fields[1]] = strings.Join(fields[2:], " ")
+	case "!set_prompt":
+		if len(fields) < 2 {
+			cprintln("usage: !set_prompt <buffer>")
+			return false
+		}
+		if v, ok := buffers[fields[1]]; ok {
+			askPrefix = v
+		} else {
+			cprintln("unknown buffer")
+		}
+	case "!get_prompt":
+		cprintln(askPrefix)
+	case "!run_on":
+		if len(fields) < 4 {
+			cprintln("usage: !run_on <buffer> <pane> <cmd>")
+			return false
+		}
+		cmdStr := replaceBufferRefs(replacePaneRefs(strings.Join(fields[3:], " ")))
+		c := exec.Command("bash", "-c", cmdStr)
+		var out bytes.Buffer
+		c.Stdout = &out
+		c.Stderr = &out
+		if err := c.Run(); err != nil {
+			cprintln("run_on error: " + err.Error())
+		}
+		buffers[fields[1]] = out.String()
+	case "!ask":
+		if len(fields) < 2 {
+			cprintln("usage: !ask <prompt>")
+			return false
+		}
+		client, err := openai.NewClient()
+		if err != nil {
+			cprintln(err.Error())
 			return false
 		}
 		promptText := replaceBufferRefs(replacePaneRefs(strings.Join(fields[1:], " ")))
-		promptText = "You are a offensive security co-pilot, please answer the following prompt with high technical accuracy from a pentesting angle. Please response to the following prompt using hacker lingo and use pithy markdown with liberal emojis: " + promptText
+		promptText = askPrefix + promptText
 		reply, err := client.SendPrompt(promptText)
 		if err != nil {
-			fmt.Println("openai error:", err)
+			cprintln("openai error: " + err.Error())
 			return false
 		}
-		cmd := exec.Command("batcat", "-l", "markdown")
+		viewer := os.Getenv("VIEWER")
+		if viewer == "" {
+			viewer = "batcat"
+		}
+		cmd := exec.Command(viewer, "-l", "markdown")
 		cmd.Stdin = strings.NewReader(reply)
 		cmd.Stdout = os.Stdout
 		if err := cmd.Run(); err != nil {
-			fmt.Println("batcat error:", err)
+			cprintln(viewer + " error: " + err.Error())
 		}
 		buffers["%code"] = lastCodeBlock(reply)
 	default:
-		fmt.Println("unknown command")
+		cprintln("unknown command")
 	}
 	return false
 }


### PR DESCRIPTION
## Summary
- extend REPL with persistent session and buffer management
- add new commands and colorized output
- support configurable editor and viewer
- run shell commands with bash and implement `run_on`
- add hotkey for pane ID insertion

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843d84776b08329abc7393736924d77