### PR TITLE
Add macOS raw terminal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A tmux-driven AI-assisted rapid prototyping interface
 
 ## About 🚀
-`grimux` is a small proof-of-concept that shows how a Go CLI can talk to tmux directly. The long term idea is to build a TUI that can capture pane contents, send them to an AI backend and display the results in another pane. For now the tool just demonstrates how to capture text from another pane via tmux's UNIX socket.
+`grimux` is a small proof-of-concept that shows how a Go CLI can talk to tmux directly. The long term idea is to build a TUI that can capture pane contents, send them to an AI backend and display the results in another pane. For now the tool just demonstrates how to capture text from another pane via tmux's UNIX socket. The REPL now works in iTerm on macOS as well as in Linux terminal emulators.
 
 When launched with no arguments the CLI now prints colorful ASCII art and asks the OpenAI API for a random, pithy complaint about dealing with nonsense. The prompt as well as the command prompt itself are decorated with a bit of color and emoji flair.
 

--- a/internal/repl/raw_darwin.go
+++ b/internal/repl/raw_darwin.go
@@ -1,0 +1,31 @@
+//go:build darwin
+
+package repl
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func startRaw() (*syscall.Termios, error) {
+	fd := int(os.Stdin.Fd())
+	var old syscall.Termios
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCGETA), uintptr(unsafe.Pointer(&old)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+	newState := old
+	newState.Lflag &^= syscall.ICANON | syscall.ECHO
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCSETA), uintptr(unsafe.Pointer(&newState)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+	return &old, nil
+}
+
+func stopRaw(state *syscall.Termios) {
+	if state == nil {
+		return
+	}
+	fd := int(os.Stdin.Fd())
+	syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCSETA), uintptr(unsafe.Pointer(state)), 0, 0, 0)
+}

--- a/internal/repl/raw_linux.go
+++ b/internal/repl/raw_linux.go
@@ -1,0 +1,31 @@
+//go:build linux
+
+package repl
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func startRaw() (*syscall.Termios, error) {
+	fd := int(os.Stdin.Fd())
+	var old syscall.Termios
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TCGETS), uintptr(unsafe.Pointer(&old)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+	newState := old
+	newState.Lflag &^= syscall.ICANON | syscall.ECHO
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TCSETS), uintptr(unsafe.Pointer(&newState)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+	return &old, nil
+}
+
+func stopRaw(state *syscall.Termios) {
+	if state == nil {
+		return
+	}
+	fd := int(os.Stdin.Fd())
+	syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TCSETS), uintptr(unsafe.Pointer(state)), 0, 0, 0)
+}

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -11,9 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"syscall"
 	"time"
-	"unsafe"
 
 	"github.com/example/grimux/internal/openai"
 	"github.com/example/grimux/internal/tmux"
@@ -95,28 +93,6 @@ func lastCodeBlock(text string) string {
 }
 
 // startRaw puts the terminal into raw mode.
-func startRaw() (*syscall.Termios, error) {
-	fd := int(os.Stdin.Fd())
-	var old syscall.Termios
-	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TCGETS), uintptr(unsafe.Pointer(&old)), 0, 0, 0); err != 0 {
-		return nil, err
-	}
-	newState := old
-	newState.Lflag &^= syscall.ICANON | syscall.ECHO
-	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TCSETS), uintptr(unsafe.Pointer(&newState)), 0, 0, 0); err != 0 {
-		return nil, err
-	}
-	return &old, nil
-}
-
-// stopRaw restores the terminal to a previous state.
-func stopRaw(state *syscall.Termios) {
-	if state == nil {
-		return
-	}
-	fd := int(os.Stdin.Fd())
-	syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TCSETS), uintptr(unsafe.Pointer(state)), 0, 0, 0)
-}
 
 // Run launches the interactive REPL.
 func Run() error {


### PR DESCRIPTION
## Summary
- add darwin and linux specific raw terminal handlers
- remove old raw mode functions from repl
- mention iTerm support in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6845c4c6fed883299ccdc7c8bfff35f9