### PR TITLE
Improve grimux README and UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,38 @@
-# grimux 🎭
-A tmux-driven AI-assisted rapid prototyping interface
+# grimux 😈
+A grimey tmux sidekick for offensive security research.
 
 ## About 🚀
-`grimux` is a small proof-of-concept that shows how a Go CLI can talk to tmux directly. The long term idea is to build a TUI that can capture pane contents, send them to an AI backend and display the results in another pane. For now the tool just demonstrates how to capture text from another pane via tmux's UNIX socket. The REPL now works in iTerm on macOS as well as in Linux terminal emulators.
+`grimux` is no longer a tiny proof of concept. It is a full blown REPL that latches on to your tmux session, captures panes and slings prompts at an LLM. It exists to aid pentesters and curious hackers who need a grumpy AI assistant that answers succinctly and with style.
 
-When launched with no arguments the CLI now prints colorful ASCII art and asks the OpenAI API for a random, pithy complaint about dealing with nonsense. The prompt as well as the command prompt itself are decorated with a bit of color and emoji flair.
+When started it shows some ASCII art, checks OpenAI connectivity and spits out a random complaint from the void. Every interaction tries to keep replies brief—one spicy sentence if possible.
+
+## Buffers ✨ (The Real Magic)
+Buffers are named scratch pads like `%file`, `%code` or anything you create. Commands can fill them with pane captures, AI replies or your own text. You can pipe buffers to files, edit them in `$EDITOR`, or feed them back into new prompts. Think of them as a hacker grimoire: snippets, notes and payloads ready at a moment’s notice.
+
+## Features 💥
+* Capture tmux panes straight into a buffer.
+* Ask the AI questions with `!ask` and view the markdown nicely rendered.
+* Store and run shell commands that reference buffers.
+* Load files into `%file`, edit buffers, or save them anywhere.
+* Horizontal separators and complimentary colors keep REPL chatter, commands and LLM responses easy to read.
+* A cute status spinner appears while the AI thinks and vanishes once it answers.
+* Sessions persist so your buffers survive restarts.
 
 ## Building 🔧
 ```bash
 go build ./cmd/grimux
 ```
 
-## Capturing a pane 📋
-```bash
-./grimux -capture <pane-id>
-```
-If `<pane-id>` is omitted, the current pane is captured.
-Pass `-verbose` to see detailed tmux communication logs.
-
-## Finding pane IDs 🆔
-You can discover the ID of each pane with `tmux list-panes -F '#{pane_id} #{pane_title}'`. The `#{pane_id}` values (like `%1`, `%2` ...) can then be passed to `-capture`.
-
-## Example session 🎬
-1. Start a new tmux session:
-   ```bash
-tmux new -s demo
-```
-2. Create a sample file and open it with `less` in the first pane:
-   ```bash
-seq 1 100 > sample.txt
-less sample.txt
-```
-3. Split the window and build `grimux` in the second pane:
-   ```bash
-# in tmux: press Ctrl-b then % (or run `tmux split-window -h`)
-go build ./cmd/grimux
-```
-4. List panes to obtain the ID of the pane running `less`:
-   ```bash
-tmux list-panes -F '#{pane_id} #{pane_current_command}'
-```
-5. Run the binary in the other pane using that ID:
-   ```bash
-./grimux -capture %1
-```
-   You should see the contents displayed in the `grimux` pane.
+## Example Workflow 🎬
+1. Fire up tmux and split some panes.
+2. Run `grimux` in one pane and issue `!list` to see buffers and pane IDs.
+3. Capture another pane’s text with `!capture %loot %1`.
+4. Summon the AI with `!var %analysis give me a quick summary`.
+5. Use `!print %analysis` or save it with `!save %analysis report.md`.
 
 ## Running tests 🧪
-Unit tests can be executed with:
 ```bash
 go test ./...
 ```
+
+Have fun spelunking through your terminal! When you exit, grimux waves goodbye with a snarky grin. 😜


### PR DESCRIPTION
## Summary
- overhaul README to showcase grimux as a grumpy tmux AI assistant
- rework ask prefix for pithy replies
- add colored separators and spinner for LLM output
- colorize command messages and show silly goodbye on exit
- ensure default ask prompt unchanged after review feedback

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6845d63795fc832990752c0a2693b189