### PR TITLE
Add encrypted sessions and improved REPL

### DIFF
--- a/internal/openai/openai.go
+++ b/internal/openai/openai.go
@@ -1,14 +1,24 @@
 package openai
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 )
 
 var apiURL = "https://api.openai.com/v1/chat/completions"
+
+var sessionAPIKey string
+
+// SetSessionAPIKey stores the API key loaded from the session file.
+func SetSessionAPIKey(k string) { sessionAPIKey = k }
+
+// GetSessionAPIKey returns the API key saved in the current session.
+func GetSessionAPIKey() string { return sessionAPIKey }
 
 // Client interacts with the OpenAI API.
 type Client struct {
@@ -19,6 +29,20 @@ type Client struct {
 // NewClient creates a client using the OPENAI_API_KEY environment variable.
 func NewClient() (*Client, error) {
 	key := os.Getenv("OPENAI_API_KEY")
+	if key == "" {
+		key = sessionAPIKey
+	}
+	if key == "" {
+		fmt.Print("OpenAI API key: ")
+		reader := bufio.NewReader(os.Stdin)
+		line, err := reader.ReadString('\n')
+		fmt.Println()
+		if err != nil {
+			return nil, err
+		}
+		key = strings.TrimSpace(line)
+		sessionAPIKey = key
+	}
 	if key == "" {
 		return nil, fmt.Errorf("OPENAI_API_KEY not set")
 	}

--- a/internal/repl/crypto.go
+++ b/internal/repl/crypto.go
@@ -1,0 +1,118 @@
+package repl
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
+	"io"
+)
+
+func pbkdf2Key(password, salt []byte, iter, keyLen int) []byte {
+	hLen := sha256.Size
+	numBlocks := (keyLen + hLen - 1) / hLen
+	dk := make([]byte, 0, numBlocks*hLen)
+	var blockBuf [4]byte
+	for block := 1; block <= numBlocks; block++ {
+		binary.BigEndian.PutUint32(blockBuf[:], uint32(block))
+		u := hmac.New(sha256.New, password)
+		u.Write(salt)
+		u.Write(blockBuf[:])
+		t := u.Sum(nil)
+		out := make([]byte, len(t))
+		copy(out, t)
+		for i := 1; i < iter; i++ {
+			u = hmac.New(sha256.New, password)
+			u.Write(t)
+			t = u.Sum(nil)
+			for j := range t {
+				out[j] ^= t[j]
+			}
+		}
+		dk = append(dk, out...)
+	}
+	return dk[:keyLen]
+}
+
+func deriveKey(pass string, salt []byte) []byte {
+	return pbkdf2Key([]byte(pass), salt, 100000, 32)
+}
+
+func compressData(b []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	if _, err := w.Write(b); err != nil {
+		return nil, err
+	}
+	if err := w.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func decompressData(b []byte) ([]byte, error) {
+	r, err := gzip.NewReader(bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	return io.ReadAll(r)
+}
+
+func encryptData(data []byte, pass string) ([]byte, error) {
+	salt := make([]byte, 16)
+	if _, err := rand.Read(salt); err != nil {
+		return nil, err
+	}
+	key := deriveKey(pass, salt)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, err
+	}
+	ct := gcm.Seal(nil, nonce, data, nil)
+	out := append(salt, append(nonce, ct...)...)
+	enc := make([]byte, base64.StdEncoding.EncodedLen(len(out)))
+	base64.StdEncoding.Encode(enc, out)
+	return enc, nil
+}
+
+func decryptData(enc []byte, pass string) ([]byte, error) {
+	raw := make([]byte, base64.StdEncoding.DecodedLen(len(enc)))
+	n, err := base64.StdEncoding.Decode(raw, enc)
+	if err != nil {
+		return nil, err
+	}
+	raw = raw[:n]
+	if len(raw) < 16 {
+		return nil, io.ErrUnexpectedEOF
+	}
+	salt := raw[:16]
+	key := deriveKey(pass, salt)
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) < 16+gcm.NonceSize() {
+		return nil, io.ErrUnexpectedEOF
+	}
+	nonce := raw[16 : 16+gcm.NonceSize()]
+	ct := raw[16+gcm.NonceSize():]
+	return gcm.Open(nil, nonce, ct, nil)
+}


### PR DESCRIPTION
## Summary
- prompt for OpenAI API key if not provided and store in session
- add AES-256-GCM encrypted session support with PBKDF2 key
- request session name and password when starting without a session
- ensure `batcat` viewer never pauses
- show REPL prompt without needing extra Enter

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6845ec50339883299dc4c085d8fa0089