### PR TITLE
Improve session UX and startup

### DIFF
--- a/cmd/grimux/main.go
+++ b/cmd/grimux/main.go
@@ -12,15 +12,14 @@ var version = "dev"
 
 func main() {
 	showVersion := flag.Bool("version", false, "print version")
-	sessionPath := flag.String("session", "", "session file to load")
 	flag.Parse()
 
 	if *showVersion {
 		fmt.Println(version)
 		return
 	}
-	if *sessionPath != "" {
-		repl.SetSessionFile(*sessionPath)
+	if flag.NArg() > 0 {
+		repl.SetSessionFile(flag.Arg(0))
 	}
 
 	if err := repl.Run(); err != nil {


### PR DESCRIPTION
## Summary
- support optional session file argument
- overhaul session prompts and saving
- tweak spinner and colors
- hint about tab completion at startup
- drop `--paging=never` for batcat
- show session name in prompt when available

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6845f3e315fc8329958e67173a6fe3ad