### PR TITLE
Fix session buffer panic

### DIFF
--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -235,6 +235,9 @@ func Run() error {
 			}
 			history = s.History
 			buffers = s.Buffers
+			if buffers == nil {
+				buffers = map[string]string{"%file": "", "%code": ""}
+			}
 			if s.Prompt != "" {
 				askPrefix = s.Prompt
 			}


### PR DESCRIPTION
## Summary
- guard against nil buffers after loading a session

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6845f673f460832982ae5f9d18d11c62