### PR TITLE
Add flow command and tmux send support

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -47,3 +47,24 @@ func CapturePane(target string) (string, error) {
 	}
 	return buf.String(), nil
 }
+
+// SendKeys sends the given keys to the specified pane using tmux send-keys.
+// The keys slice is passed as individual arguments to the tmux command.
+func SendKeys(target string, keys ...string) error {
+	tmuxEnv := os.Getenv("TMUX")
+	if tmuxEnv == "" {
+		return errors.New("TMUX environment variable is not set")
+	}
+	socket := strings.Split(tmuxEnv, ",")[0]
+	if _, err := os.Stat(socket); err != nil {
+		return fmt.Errorf("tmux socket missing: %w", err)
+	}
+	args := []string{"-S", socket, "send-keys"}
+	if target != "" {
+		args = append(args, "-t", target)
+	}
+	args = append(args, keys...)
+	debugf("running: tmux %s", strings.Join(args, " "))
+	cmd := exec.Command("tmux", args...)
+	return cmd.Run()
+}

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -80,3 +80,23 @@ func TestCapturePaneCurrent(t *testing.T) {
 		t.Fatalf("unexpected args: %q", args)
 	}
 }
+
+func TestSendKeys(t *testing.T) {
+	sock, argsFile, cleanup := startFakeTmux(t, "")
+	defer cleanup()
+	os.Setenv("TMUX", sock+",session")
+
+	if err := SendKeys("%2", "echo", "hi", "Enter"); err != nil {
+		t.Fatalf("SendKeys: %v", err)
+	}
+
+	b, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read args: %v", err)
+	}
+	args := string(bytes.TrimSpace(b))
+	expected := fmt.Sprintf("-S %s send-keys -t %s echo hi Enter", sock, "%2")
+	if args != expected {
+		t.Fatalf("unexpected args: %q", args)
+	}
+}


### PR DESCRIPTION
## Summary
- add tmux.SendKeys helper for sending input to panes
- support `!flow` command to chain prompts across buffers
- use tmux send-keys in `!run_on`
- implement Ctrl+A/Ctrl+E/Ctrl+U shortcuts
- test tmux.SendKeys

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68461167428083298d1197dc9e3f3f4e