### PR TITLE
Add customizable API host and YAML config support

### DIFF
--- a/internal/openai/openai_test.go
+++ b/internal/openai/openai_test.go
@@ -13,12 +13,13 @@ func TestSendPrompt(t *testing.T) {
 		w.Write([]byte(`{"choices": [{"message": {"content": "ok"}}]}`))
 	}))
 	defer srv.Close()
-
-	c := &Client{APIKey: "test", HTTPClient: srv.Client()}
-	// override URL via environment variable (not in client yet). We'll mimic by patching constant, but constant not defined.
-	// So simply set custom server endpoint by new request - we can't patch constant elegantly.
-	// Instead we patch by using a variable for endpoint.
 	_ = os.Setenv("OPENAI_API_URL", srv.URL)
+	_ = os.Setenv("OPENAI_API_KEY", "test")
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	c.HTTPClient = srv.Client()
 	reply, err := c.SendPrompt("hi")
 	if err != nil {
 		t.Fatalf("SendPrompt: %v", err)


### PR DESCRIPTION
## Summary
- add ability to configure API host and persist it with the API key
- look for `~/.grimuxrc` to load API key, API url and custom ask prefix
- store API url in sessions
- update OpenAI client to prompt for host if needed
- update tests for new client behaviour

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68461bd049e88329adeddf376cd3d3f6