### PR TITLE
Rename REPL commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ When started it shows some ASCII art, checks OpenAI connectivity and spits out a
 Buffers are named scratch pads like `%file`, `%code` or anything you create. Commands can fill them with pane captures, AI replies or your own text. You can pipe buffers to files, edit them in `$EDITOR`, or feed them back into new prompts. Think of them as a hacker grimoire: snippets, notes and payloads ready at a moment’s notice.
 
 ## Features 💥
-* Capture tmux panes straight into a buffer.
-* Ask the AI questions with `!ask` and view the markdown nicely rendered.
+* Capture tmux panes straight into a buffer with `!observe`.
+* Ask the AI questions with `!a` and view the markdown nicely rendered.
 * Store and run shell commands that reference buffers.
-* Load files into `%file`, edit buffers, or save them anywhere.
+* Load files into `%file` via `!load`, edit buffers, or save them anywhere.
 * Horizontal separators and complimentary colors keep REPL chatter, commands and LLM responses easy to read.
 * A cute status spinner appears while the AI thinks and vanishes once it answers.
 * Sessions persist so your buffers survive restarts.
@@ -25,10 +25,10 @@ go build ./cmd/grimux
 
 ## Example Workflow 🎬
 1. Fire up tmux and split some panes.
-2. Run `grimux` in one pane and issue `!list` to see buffers and pane IDs.
-3. Capture another pane’s text with `!capture %loot %1`.
-4. Summon the AI with `!var %analysis give me a quick summary`.
-5. Use `!print %analysis` or save it with `!save %analysis report.md`.
+2. Run `grimux` in one pane and issue `!ls` to see buffers and pane IDs.
+3. Capture another pane’s text with `!observe %loot %1`.
+4. Summon the AI with `!gen %analysis give me a quick summary`.
+5. Use `cat %analysis` or save it with `!save %analysis report.md`.
 
 ## Running tests 🧪
 ```bash


### PR DESCRIPTION
## Summary
- rename various REPL commands (`!exit`->`!x`, `!ask`->`!a`, `!var`->`!gen`, `!varcode`->`!code`, `!file`->`!load`, `!print`->`cat`, `!prompt`->`!set`, `!set_prompt`->`!prefix`, `!list`->`!ls`, `!capture`->`!observe`)
- add new `!unset` command to clear buffers
- update help/command list and examples in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684639669e748329b1bd775dc90efd5f