### PR TITLE
Add advanced REPL commands and model selection

### DIFF
--- a/internal/openai/openai.go
+++ b/internal/openai/openai.go
@@ -12,6 +12,9 @@ import (
 
 const defaultAPIURL = "https://api.openai.com/v1/chat/completions"
 
+// ModelName controls which OpenAI model is used for requests.
+var ModelName = "gpt-4o"
+
 var sessionAPIURL string
 
 var sessionAPIKey string
@@ -27,6 +30,12 @@ func GetSessionAPIKey() string { return sessionAPIKey }
 
 // GetSessionAPIURL returns the API URL saved in the current session.
 func GetSessionAPIURL() string { return sessionAPIURL }
+
+// SetModelName sets the OpenAI model name used by SendPrompt.
+func SetModelName(n string) { ModelName = n }
+
+// GetModelName returns the current OpenAI model name.
+func GetModelName() string { return ModelName }
 
 // Client interacts with the OpenAI API.
 type Client struct {
@@ -101,7 +110,7 @@ type chatResponse struct {
 // SendPrompt sends the given text as a user message and returns the assistant's reply.
 func (c *Client) SendPrompt(prompt string) (string, error) {
 	reqBody := chatRequest{
-		Model:    "gpt-4o",
+		Model:    ModelName,
 		Messages: []chatMessage{{Role: "user", Content: prompt}},
 	}
 	b, err := json.Marshal(reqBody)

--- a/internal/openai/openai_test.go
+++ b/internal/openai/openai_test.go
@@ -28,3 +28,12 @@ func TestSendPrompt(t *testing.T) {
 		t.Fatalf("unexpected reply: %q", reply)
 	}
 }
+
+func TestSetModelName(t *testing.T) {
+	old := GetModelName()
+	SetModelName("dummy")
+	if GetModelName() != "dummy" {
+		t.Fatalf("model not set")
+	}
+	SetModelName(old)
+}


### PR DESCRIPTION
## Summary
- make OpenAI model configurable
- add lots of new REPL commands such as `!file`, `!grep`, `!cd`, `!pwd`, etc.
- store model in sessions
- complete buffer names with tab autocomplete

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68464445bdf0832985df8258c997a718