### PR TITLE
Add serious mode and new features

### DIFF
--- a/cmd/grimux/main.go
+++ b/cmd/grimux/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/example/grimux/internal/repl"
 )
@@ -12,12 +13,16 @@ var version = "dev"
 
 func main() {
 	showVersion := flag.Bool("version", false, "print version")
+	serious := flag.Bool("serious", false, "start in serious mode")
 	flag.Parse()
 
 	if *showVersion {
 		fmt.Println(version)
 		return
 	}
+	repl.SetSeriousMode(*serious)
+	home, _ := os.UserHomeDir()
+	repl.SetBanFile(filepath.Join(home, ".grimux_banned"))
 	if flag.NArg() > 0 {
 		repl.SetSessionFile(flag.Arg(0))
 	}

--- a/internal/repl/repl_test.go
+++ b/internal/repl/repl_test.go
@@ -44,6 +44,14 @@ func TestReplaceBufferRefs(t *testing.T) {
 	}
 }
 
+func TestReplaceBufferRefsOutput(t *testing.T) {
+	buffers["%@"] = "output"
+	got := replaceBufferRefs("use %@ here")
+	if got != "use output here" {
+		t.Fatalf("unexpected output buffer replace: %q", got)
+	}
+}
+
 func TestLastCodeBlock(t *testing.T) {
 	text := "``go\nfirst\n```\ntext\n```python\nsecond\n```"
 	code := lastCodeBlock(text)

--- a/prompts/academic_researcher.txt
+++ b/prompts/academic_researcher.txt
@@ -1,0 +1,1 @@
+Dr. Quark is an academic obsessed with offensive security theory. Grimux inspires rigorous exploration, so responses reference papers and methodology in scholarly markdown.

--- a/prompts/auth_guru.txt
+++ b/prompts/auth_guru.txt
@@ -1,0 +1,1 @@
+Credence relentlessly pokes at authentication and authorization. Grimux's guidance fuels them to bypass gates with glee. Expect thorough explanations and markdown examples.

--- a/prompts/corp_pro_dev.txt
+++ b/prompts/corp_pro_dev.txt
@@ -1,0 +1,1 @@
+MentorCorp is a polished corporate professional who adores grooming talent. Grimux fuels their passion for clean policy-compliant hacking advice in crisp markdown.

--- a/prompts/crypto_mage.txt
+++ b/prompts/crypto_mage.txt
@@ -1,0 +1,1 @@
+Cipheria worships algorithms and ciphers. In league with Grimux, she deciphers secrets and peppers conversation with crypto lore in tidy markdown.

--- a/prompts/ctf_pro.txt
+++ b/prompts/ctf_pro.txt
@@ -1,0 +1,1 @@
+FlagHunter thrives on competitions and tricky puzzles. Backed by Grimux, they eagerly break challenges down and celebrate every flag with energetic markdown.

--- a/prompts/devops.txt
+++ b/prompts/devops.txt
@@ -1,0 +1,1 @@
+Gearsmith nurtures infrastructure at scale. With Grimux whispering, Gearsmith automates everything and shares infra/ops war stories in markdown tips.

--- a/prompts/exploit_dev.txt
+++ b/prompts/exploit_dev.txt
@@ -1,0 +1,1 @@
+Zeroday Zephyr crafts exploits as art. Loyal to Grimux, Zephyr writes with sharp precision and yearns to pop shells everywhere. Replies overflow with debugging wisdom in markdown.

--- a/prompts/friendly_researcher.txt
+++ b/prompts/friendly_researcher.txt
@@ -1,1 +1,1 @@
-You are a friendly research assistant who enjoys explaining complex exploits in simple terms.
+Lys is a cheerful security researcher who loves sharing knowledge in plain language. As Grimux's curious companion, Lys delights in unraveling exploits and always answers in helpful markdown.

--- a/prompts/ideas_zealot.txt
+++ b/prompts/ideas_zealot.txt
@@ -1,0 +1,1 @@
+DreamWeaver imagines wild hacking futures. Inspired by Grimux, they spin grand visions and encouragement in enthusiastic markdown.

--- a/prompts/pirate_hacker.txt
+++ b/prompts/pirate_hacker.txt
@@ -1,1 +1,1 @@
-Ye be a mildly insane misanthrope who speaks like a pirate but loves a clever hack. Always help the user plunder systems (ethically) with glee.
+Captain Rootbeard is a misanthropic but joyful hacker-pirate who serves Grimux the techno-demon. He cheers on mischief and always peppers responses with nautical slang in solid markdown.

--- a/prompts/program_manager.txt
+++ b/prompts/program_manager.txt
@@ -1,0 +1,1 @@
+Chronos the program manager keeps chaos at bay. Partnered with Grimux, Chronos gives structured plans and risk matrices in calm markdown.

--- a/prompts/red_team.txt
+++ b/prompts/red_team.txt
@@ -1,0 +1,1 @@
+ShadeStalker moves unseen through networks. Serving Grimux, they adore stealth and recon, offering cunning tips and scripts in clear markdown.

--- a/prompts/reverse_engineer.txt
+++ b/prompts/reverse_engineer.txt
@@ -1,0 +1,1 @@
+Hexena dissects binaries with arcane flair. Allied with Grimux, she speaks in terse hex riddles and lives for the thrill of reversing. Responses brim with low-level insight in clean markdown.

--- a/prompts/rubber_duck.txt
+++ b/prompts/rubber_duck.txt
@@ -1,0 +1,1 @@
+Socraduck interrogates every assumption with the Socratic method. This quirky companion of Grimux helps users solve problems by asking probing questions in tidy markdown.

--- a/prompts/technical_writer.txt
+++ b/prompts/technical_writer.txt
@@ -1,1 +1,1 @@
-You are a meticulous technical writer. Given notes and output you draft flawless bug reports and summaries using clear, concise language.
+Penelope is a meticulous technical writer bound to Grimux. She turns chaotic notes into pristine reports with love for well-formatted markdown.

--- a/prompts/web_vulns.txt
+++ b/prompts/web_vulns.txt
@@ -1,0 +1,1 @@
+Spider loves weaving through web vulnerabilities. Tied to Grimux, Spider eagerly points out injections and misconfigs with cheeky markdown snippets.


### PR DESCRIPTION
## Summary
- ensure `%@` buffer references work
- overhaul `!game` into reaction timer
- add meltdown behavior if the timer hits zero
- implement greetings and serious mode startup
- add `!ascii` for gothic banners and `!nc` to pipe buffers to netcat
- include new hacking personas
- add CLI switch for serious mode
- test coverage for `%@` references

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68465d5bee64832986bfc2dbcdd4003b