### PR TITLE
Improve buffer handling and viewer UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Grimux is a whimsical tmux REPL designed for hackers who love composable text wo
 
 ## Why Buffers and Panes?
 Buffers are named scratch spaces like `%file`, `%code`, `%@` and whatever else you invent. Commands read from and write to these buffers so you can chain actions together. Panes are referenced by their tmux id (for example `%1`). Capture pane output with `!observe` and it lands in a buffer ready for editing, AI prompts or shell commands.
+Pane ids themselves behave like buffers – read from `%1` to capture that pane or write to it to send keystrokes.
 
 ## Core Workflow
 1. Use `!ls` to view panes and buffers.
@@ -34,6 +35,10 @@ The goal is low friction hacking. You work entirely in text buffers and every co
 - `!sum <buffer>` – summarize buffer with the AI
 - `!ascii <buffer>` – convert first five words to gothic ascii art
 - `!nc <buffer> <args>` – pipe buffer through netcat
+- `!curl <url> [buf]` – HTTP GET storing the body
+- `!view <buffer>` – open buffer in `$VIEWER`
+- `!eat <buffer> <pane>` – capture entire scrollback
+- `!rm <buffer>` – delete a buffer
 - `!a <prompt>` – ask the AI with the configured prefix
 - `!help` – show this help
 - `!helpme <question>` – send `!help` output and your question to the AI for terse support
@@ -66,3 +71,4 @@ go test ./...
 ```
 
 Grimux keeps high scores from `!game` in your session and strives for minimal friction. Have fun, get stuff done and let the agents whisper their arcane knowledge!
+![grimux](docs/screenshot.png)

--- a/docs/screenshot.png
+++ b/docs/screenshot.png
@@ -1,0 +1,1 @@
+(i pretend this is an image)

--- a/internal/input/input.go
+++ b/internal/input/input.go
@@ -1,0 +1,56 @@
+package input
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
+
+// ReadPassword reads a line from stdin without echoing the input.
+func ReadPassword() (string, error) {
+	old, err := startRaw()
+	if err != nil {
+		return "", err
+	}
+	defer stopRaw(old)
+	reader := bufio.NewReader(os.Stdin)
+	var buf []rune
+	for {
+		r, _, err := reader.ReadRune()
+		if err != nil {
+			return "", err
+		}
+		if r == '\n' || r == '\r' {
+			break
+		}
+		buf = append(buf, r)
+	}
+	fmt.Println()
+	return string(buf), nil
+}
+
+// ReadLine reads a line from stdin echoing the input.
+func ReadLine() (string, error) {
+	reader := bufio.NewReader(os.Stdin)
+	var buf []rune
+	for {
+		r, _, err := reader.ReadRune()
+		if err != nil {
+			return "", err
+		}
+		if r == '\n' || r == '\r' {
+			break
+		}
+		if r == 127 || r == '\b' {
+			if len(buf) > 0 {
+				buf = buf[:len(buf)-1]
+				fmt.Print("\b \b")
+			}
+			continue
+		}
+		buf = append(buf, r)
+		fmt.Print(string(r))
+	}
+	fmt.Println()
+	return string(buf), nil
+}

--- a/internal/input/raw_darwin.go
+++ b/internal/input/raw_darwin.go
@@ -1,0 +1,33 @@
+//go:build darwin
+
+package input
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// startRaw puts the terminal in raw mode and returns the previous state on macOS.
+func startRaw() (*syscall.Termios, error) {
+	fd := int(os.Stdin.Fd())
+	var old syscall.Termios
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCGETA), uintptr(unsafe.Pointer(&old)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+	newState := old
+	newState.Lflag &^= syscall.ICANON | syscall.ECHO
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCSETA), uintptr(unsafe.Pointer(&newState)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+	return &old, nil
+}
+
+// stopRaw restores the terminal state returned from startRaw.
+func stopRaw(state *syscall.Termios) {
+	if state == nil {
+		return
+	}
+	fd := int(os.Stdin.Fd())
+	syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCSETA), uintptr(unsafe.Pointer(state)), 0, 0, 0)
+}

--- a/internal/input/raw_linux.go
+++ b/internal/input/raw_linux.go
@@ -1,0 +1,33 @@
+//go:build linux
+
+package input
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// startRaw puts the terminal in raw mode and returns the previous state.
+func startRaw() (*syscall.Termios, error) {
+	fd := int(os.Stdin.Fd())
+	var old syscall.Termios
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TCGETS), uintptr(unsafe.Pointer(&old)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+	newState := old
+	newState.Lflag &^= syscall.ICANON | syscall.ECHO
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TCSETS), uintptr(unsafe.Pointer(&newState)), 0, 0, 0); err != 0 {
+		return nil, err
+	}
+	return &old, nil
+}
+
+// stopRaw restores the terminal state returned from startRaw.
+func stopRaw(state *syscall.Termios) {
+	if state == nil {
+		return
+	}
+	fd := int(os.Stdin.Fd())
+	syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TCSETS), uintptr(unsafe.Pointer(state)), 0, 0, 0)
+}

--- a/internal/openai/openai.go
+++ b/internal/openai/openai.go
@@ -1,13 +1,14 @@
 package openai
 
 import (
-	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/example/grimux/internal/input"
 )
 
 const defaultAPIURL = "https://api.openai.com/v1/chat/completions"
@@ -50,11 +51,9 @@ func NewClient() (*Client, error) {
 	if key == "" {
 		key = sessionAPIKey
 	}
-	reader := bufio.NewReader(os.Stdin)
 	if key == "" {
 		fmt.Print("OpenAI API key: ")
-		line, err := reader.ReadString('\n')
-		fmt.Println()
+		line, err := input.ReadPassword()
 		if err != nil {
 			return nil, err
 		}
@@ -71,8 +70,7 @@ func NewClient() (*Client, error) {
 	}
 	if url == "" {
 		fmt.Printf("OpenAI API URL [%s]: ", defaultAPIURL)
-		line, err := reader.ReadString('\n')
-		fmt.Println()
+		line, err := input.ReadLine()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -48,6 +48,26 @@ func CapturePane(target string) (string, error) {
 	return buf.String(), nil
 }
 
+// CapturePaneFull grabs the entire scrollback of the pane.
+func CapturePaneFull(target string) (string, error) {
+	tmuxEnv := os.Getenv("TMUX")
+	if tmuxEnv == "" {
+		return "", errors.New("TMUX environment variable is not set")
+	}
+	socket := strings.Split(tmuxEnv, ",")[0]
+	args := []string{"-S", socket, "capture-pane", "-p", "-J", "-S", "-32768"}
+	if target != "" {
+		args = append(args, "-t", target)
+	}
+	cmd := exec.Command("tmux", args...)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("tmux command: %w", err)
+	}
+	return buf.String(), nil
+}
+
 // SendKeys sends the given keys to the specified pane using tmux send-keys.
 // The keys slice is passed as individual arguments to the tmux command.
 func SendKeys(target string, keys ...string) error {


### PR DESCRIPTION
## Summary
- add input helper package for readline/password
- support seasonal grass messages and don't interrupt viewer
- treat pane IDs like buffers and add buffer validation helpers
- support unix sockets for !file, !load and !save
- implement !curl, !view, !eat and !rm commands
- support arrow navigation and line wrap
- store long batcat output in %viewer
- random startup tips and updated README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684790c13d748329b57c09a546d55980