### PR TITLE
Add completions and help hotkey

### DIFF
--- a/internal/repl/completer.go
+++ b/internal/repl/completer.go
@@ -1,0 +1,59 @@
+package repl
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/chzyer/readline"
+
+	"github.com/example/grimux/internal/tmux"
+)
+
+type autoCompleter struct{}
+
+func (c *autoCompleter) Do(line []rune, pos int) ([][]rune, int) {
+	input := string(line[:pos])
+	fields := strings.Fields(input)
+	prefix := ""
+	if len(fields) > 0 && !strings.HasSuffix(input, " ") {
+		prefix = fields[len(fields)-1]
+	}
+	var suggestions []string
+	if strings.HasPrefix(prefix, "%") {
+		for name := range buffers {
+			if strings.HasPrefix(name, prefix) {
+				suggestions = append(suggestions, name[len(prefix):])
+			}
+		}
+		ids, _ := tmux.ListPaneIDs()
+		for _, id := range ids {
+			if strings.HasPrefix(id, prefix) {
+				suggestions = append(suggestions, id[len(prefix):])
+			}
+		}
+		matches, _ := filepath.Glob(prefix + "*")
+		for _, m := range matches {
+			if strings.HasPrefix(m, prefix) {
+				suggestions = append(suggestions, m[len(prefix):])
+			}
+		}
+	} else if strings.HasPrefix(prefix, "!") || len(fields) == 0 {
+		for name := range commands {
+			if strings.HasPrefix(name, prefix) {
+				suggestions = append(suggestions, name[len(prefix):])
+			}
+		}
+	} else {
+		matches, _ := filepath.Glob(prefix + "*")
+		for _, m := range matches {
+			if strings.HasPrefix(m, prefix) {
+				suggestions = append(suggestions, m[len(prefix):])
+			}
+		}
+	}
+	out := make([][]rune, len(suggestions))
+	for i, s := range suggestions {
+		out[i] = []rune(s)
+	}
+	return out, len([]rune(prefix))
+}

--- a/internal/repl/help_listener.go
+++ b/internal/repl/help_listener.go
@@ -1,0 +1,35 @@
+package repl
+
+import (
+	"fmt"
+	"strings"
+)
+
+// helpListener intercepts '?' key presses to display inline help.
+type helpListener struct{}
+
+func (h *helpListener) OnChange(line []rune, pos int, key rune) ([]rune, int, bool) {
+	if key != '?' {
+		return nil, 0, false
+	}
+	if pos > 0 {
+		line = append(line[:pos-1], line[pos:]...)
+		pos--
+	}
+	trimmed := strings.TrimSpace(string(line))
+	fmt.Println()
+	if trimmed == "" {
+		handleCommand("!help")
+	} else if strings.HasPrefix(trimmed, "!") {
+		fields := strings.Fields(trimmed)
+		name := fields[0]
+		if info, ok := commands[name]; ok {
+			cmdPrintln(info.Usage + " - " + info.Desc)
+			for _, p := range info.Params {
+				cmdPrintln(fmt.Sprintf("  %s - %s", p.Name, p.Desc))
+			}
+		}
+	}
+	forceEnter()
+	return line, pos, true
+}

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -689,12 +689,20 @@ func Run() error {
 		}
 	}()
 
-	rl, err := readline.NewEx(&readline.Config{HistoryFile: filepath.Join(home, ".grimux_history")})
+	cfg := readline.Config{
+		DisableAutoSaveHistory: true,
+		AutoComplete:           &autoCompleter{},
+		Listener:               &helpListener{},
+	}
+	rl, err := readline.NewEx(&cfg)
 	if err != nil {
 		return err
 	}
 	defer rl.Close()
 	input.SetReadline(rl)
+	for _, h := range history {
+		rl.SaveHistory(h)
+	}
 
 	setPrompt := func() {
 		if sessionName != "" {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -88,3 +88,21 @@ func SendKeys(target string, keys ...string) error {
 	cmd := exec.Command("tmux", args...)
 	return cmd.Run()
 }
+
+// ListPaneIDs returns the IDs of all tmux panes.
+func ListPaneIDs() ([]string, error) {
+	tmuxEnv := os.Getenv("TMUX")
+	if tmuxEnv == "" {
+		return nil, errors.New("TMUX environment variable is not set")
+	}
+	socket := strings.Split(tmuxEnv, ",")[0]
+	args := []string{"-S", socket, "list-panes", "-F", "#{pane_id}"}
+	cmd := exec.Command("tmux", args...)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("tmux command: %w", err)
+	}
+	out := strings.Fields(buf.String())
+	return out, nil
+}


### PR DESCRIPTION
## Summary
- add tmux pane listing helper
- provide tab completion for commands, buffers, panes and paths
- install a '?' hotkey listener
- keep command history inside encrypted session

## Testing
- `go build ./cmd/grimux`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6847a3338e2c83298559acd04744349c