### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: darwin
+            goarch: arm64
+            artifact: grimux-darwin-arm64
+          - goos: linux
+            goarch: arm64
+            artifact: grimux-linux-arm64
+          - goos: linux
+            goarch: amd64
+            artifact: grimux-linux-amd64
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+      - name: Build
+        run: |
+          VERSION=${GITHUB_REF##*/}
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags "-s -w -X main.version=$VERSION" -o grimux ./cmd/grimux
+          tar -czf ${{ matrix.artifact }}.tar.gz grimux
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.tar.gz
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: artifacts/**/*.tar.gz


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build binaries for macOS arm64 and Linux arm64/amd64

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6847ba5e18c48329b12dbc8c7005b247