### PR TITLE
Disable readline when saving session

### DIFF
--- a/internal/input/input.go
+++ b/internal/input/input.go
@@ -13,6 +13,9 @@ var rl *readline.Instance
 // SetReadline assigns the global readline instance used for interactive input.
 func SetReadline(r *readline.Instance) { rl = r }
 
+// GetReadline returns the current global readline instance.
+func GetReadline() *readline.Instance { return rl }
+
 // ReadPasswordPrompt reads a secret line displaying the given prompt.
 func ReadPasswordPrompt(prompt string) (string, error) {
 	if rl != nil {

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -823,6 +823,12 @@ func Run() error {
 
 // handleCommand executes a ! command. Returns true if repl should quit.
 func saveSession() {
+	// Temporarily disable readline so prompts work correctly in raw mode
+	rl := input.GetReadline()
+	if rl != nil {
+		input.SetReadline(nil)
+		defer input.SetReadline(rl)
+	}
 	if sessionFile == "" {
 		if sessionName != "" {
 			cprint(fmt.Sprintf("Session name [%s]: ", sessionName))


### PR DESCRIPTION
## Summary
- expose current readline instance via `input.GetReadline`
- temporarily disable readline before prompting for session name/password

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6847bed939a48329b0481bd6aa679c47