### PR TITLE
Add plugin print API and mute toggle

### DIFF
--- a/plugins/sample.lua
+++ b/plugins/sample.lua
@@ -1,7 +1,8 @@
 function init(handle)
   local info = {name="sample", grimux="0.1.0", version="0.1.0"}
   local json = "{\"name\":\"" .. info.name .. "\",\"grimux\":\"" .. info.grimux .. "\",\"version\":\"" .. info.version .. "\"}"
-  plugin.register(json)
+  plugin.register(handle, json)
+  plugin.print(handle, "sample plugin loaded")
 end
 
 function shutdown(handle)


### PR DESCRIPTION
## Summary
- extend plugin manager with print handler and mute support
- verify plugin handles and return them from API calls
- queue plugin messages and display when the REPL is idle
- allow `!plugin mute` to toggle plugin output
- update sample plugin to show startup message

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68490ba0f1cc832981d58a3425df7258