### PR TITLE
Implement diff/recap and null buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Buffers are scratch spaces like `%file`, `%code` and `%@`. They hold text for
 commands to consume or produce. Panes are addressed by their tmux id (e.g. `%1`).
 `!observe %buf %1` captures pane output into `%buf`; sending text to a pane works
 the same way using its id as a buffer name.
+Use `%null` when you want to discard output entirely.
 
 ## Core workflow
 1. `!ls` shows available panes and buffers
@@ -47,6 +48,7 @@ the same way using its id as a buffer name.
 - `!prefix <buffer|file>` – set prefix from buffer or file
 - `!reset` – reset session and prefix
 - `!unset <buffer>` – clear buffer
+- `%null` – special buffer that discards all writes and always reads empty
 - `!get_prompt` – show current prefix
 - `!session` – store session JSON in `%session`
 - `!run_on <buffer> <pane> <cmd>` – run command using pane capture
@@ -62,7 +64,9 @@ the same way using its id as a buffer name.
 - `!rand <min> <max> <buffer>` – store random number
 - `!ascii <buffer>` – gothic ascii art of first 5 words
 - `!nc <buffer> <args>` – pipe buffer to netcat
-- `!curl <url> [buffer]` – HTTP GET and store body
+- `!curl <url> [buffer] [headers]` – HTTP GET and store body with optional headers
+- `!diff <left> <right> [buffer]` – diff two buffers or files
+- `!recap` – summarize the session
 - `!eat <buffer> <pane>` – capture full scrollback
 - `!view <buffer>` – show buffer in `$VIEWER`
 - `!rm <buffer>` – remove a buffer

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -82,7 +82,9 @@ Below is an expanded reference with ideas for how each command might aid your re
 - `!run [buf] <cmd>` – execute a shell command, optionally piping in a buffer. Use this to compile code or run enumeration scripts.
 - `!run_on <buf> <pane> <cmd>` – capture a pane, run a command with that capture as input, store output in `<buf>`.
 - `!nc <buf> <args>` – pipe a buffer to netcat. Convenient for sending crafted payloads.
-- `!curl <url> [buf]` – fetch a URL directly into a buffer for offline review.
+- `!curl <url> [buf] [hdrs]` – fetch a URL into a buffer, optionally using headers from `hdrs`.
+- `!diff <a> <b> [buf]` – show a colorized diff between buffers or files.
+- `!recap` – summarize the session.
 
 ### AI Integration
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -75,6 +75,7 @@ Below is an expanded reference with ideas for how each command might aid your re
 - `!edit <buf>` – open `$EDITOR` to modify text.
 - `!save <buf> <file>` / `!file <path> [buf]` – move between buffers and files.
 - `!unset <buf>` / `!rm <buf>` – clear or remove a buffer when done.
+- `%null` – special buffer that discards writes and always reads empty.
 - `!grep <regex> [buffers...]` – search through your captured data.
 
 ### Running Commands

--- a/internal/repl/repl_test.go
+++ b/internal/repl/repl_test.go
@@ -59,3 +59,10 @@ func TestLastCodeBlock(t *testing.T) {
 		t.Fatalf("unexpected last code block: %q", code)
 	}
 }
+
+func TestNullBuffer(t *testing.T) {
+	writeBuffer("%null", "ignored")
+	if val, ok := readBuffer("%null"); !ok || val != "" {
+		t.Fatal("%null should always be empty")
+	}
+}


### PR DESCRIPTION
## Summary
- add `%null` buffer with special semantics
- implement HTTP header support for `!curl`
- add `!diff` command using `git diff` and `cdiff`
- introduce `!recap` command for AI-generated session summaries
- document new commands
- test `%null` buffer behavior

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684e4263ac288329a17dd1d1a870031a