### PR TITLE
Add plugin HTTP API

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -134,6 +134,30 @@ func (m *Manager) Load(path string) (*Plugin, error) {
 			L.Push(lua.LString(p.Handle))
 			return 1
 		},
+		"format": func(L *lua.LState) int {
+			handle := L.CheckString(1)
+			if handle != p.Handle {
+				L.RaiseError("invalid handle")
+				return 0
+			}
+			format := L.CheckString(2)
+			args := make([]interface{}, 0, L.GetTop()-2)
+			for i := 3; i <= L.GetTop(); i++ {
+				val := L.Get(i)
+				switch v := val.(type) {
+				case lua.LBool:
+					args = append(args, bool(v))
+				case lua.LNumber:
+					args = append(args, float64(v))
+				case lua.LString:
+					args = append(args, string(v))
+				default:
+					args = append(args, val.String())
+				}
+			}
+			L.Push(lua.LString(fmt.Sprintf(format, args...)))
+			return 1
+		},
 		"http": func(L *lua.LState) int {
 			handle := L.CheckString(1)
 			if handle != p.Handle {

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -1,0 +1,50 @@
+package plugin
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	lua "github.com/yuin/gopher-lua"
+)
+
+func TestHTTP(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"ok":true}`)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	luaFile := filepath.Join(dir, "plug.lua")
+	code := fmt.Sprintf(`
+function init(h)
+  local info = {name="plug", grimux="0.1.0", version="0.1.0"}
+  local json = "{\"name\":\"plug\",\"grimux\":\"0.1.0\",\"version\":\"0.1.0\"}"
+  plugin.register(h, json)
+  local resp, status = plugin.http(h, "GET", "%s")
+  got_ok = resp.ok
+  got_status = status
+end
+`, srv.URL)
+	if err := os.WriteFile(luaFile, []byte(code), 0o600); err != nil {
+		t.Fatalf("write lua: %v", err)
+	}
+
+	SetPrintHandler(func(*Plugin, string) {})
+	p, err := GetManager().Load(luaFile)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	defer GetManager().Unload(p.Info.Name)
+
+	if v := p.L.GetGlobal("got_ok"); v != lua.LTrue {
+		t.Fatalf("expected true, got %v", v)
+	}
+	if v := p.L.GetGlobal("got_status"); lua.LVAsNumber(v) != 200 {
+		t.Fatalf("expected 200, got %v", v)
+	}
+}

--- a/plugins/http_sample.lua
+++ b/plugins/http_sample.lua
@@ -1,6 +1,6 @@
 function init(handle)
   local info = {name="http_sample", grimux="0.1.0", version="0.1.0"}
-  local json = string.format('{"name":"%s","grimux":"%s","version":"%s"}', info.name, info.grimux, info.version)
+  local json = plugin.format(handle, '{"name":"%s","grimux":"%s","version":"%s"}', info.name, info.grimux, info.version)
   plugin.register(handle, json)
   plugin.print(handle, "http sample loaded")
 

--- a/plugins/http_sample.lua
+++ b/plugins/http_sample.lua
@@ -1,0 +1,26 @@
+function init(handle)
+  local info = {name="http_sample", grimux="0.1.0", version="0.1.0"}
+  local json = string.format('{"name":"%s","grimux":"%s","version":"%s"}', info.name, info.grimux, info.version)
+  plugin.register(handle, json)
+  plugin.print(handle, "http sample loaded")
+
+  -- GET request with params and headers
+  local getOpts = '{"params":{"a":"1","b":"two"},"headers":{"X-Test":"yes"}}'
+  local resp, status = plugin.http(handle, "GET", "https://httpbin.org/get", getOpts)
+  plugin.print(handle, "GET status: " .. status .. ", url=" .. resp.url)
+
+  -- POST form data
+  local formOpts = '{"form":{"foo":"bar","baz":"qux"},"headers":{"X-Form":"true"}}'
+  local resp2, status2 = plugin.http(handle, "POST", "https://httpbin.org/post", formOpts)
+  plugin.print(handle, "POST form status: " .. status2 .. ", foo=" .. resp2.form.foo)
+
+  -- POST JSON body
+  local jsonOpts = '{"json":{"hello":"world","number":42},"headers":{"X-JSON":"true"}}'
+  local resp3, status3 = plugin.http(handle, "POST", "https://httpbin.org/post", jsonOpts)
+  plugin.print(handle, "POST JSON status: " .. status3 .. ", hello=" .. resp3.json.hello)
+end
+
+function shutdown(handle)
+  -- cleanup
+end
+

--- a/plugins/sample.lua
+++ b/plugins/sample.lua
@@ -1,6 +1,6 @@
 function init(handle)
   local info = {name="sample", grimux="0.1.0", version="0.1.0"}
-  local json = "{\"name\":\"" .. info.name .. "\",\"grimux\":\"" .. info.grimux .. "\",\"version\":\"" .. info.version .. "\"}"
+  local json = plugin.format(handle, '{"name":"%s","grimux":"%s","version":"%s"}', info.name, info.grimux, info.version)
   plugin.register(handle, json)
   plugin.print(handle, "sample plugin loaded")
 end


### PR DESCRIPTION
## Summary
- add `plugin.http` to allow GET and POST requests with headers, params and bodies
- convert JSON responses to Lua tables
- tests for the new HTTP helper
- add sample plugin exercising GET and POST requests with options

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68570867127c8329b61b23bb9c49b05d