### PR TITLE
Add extensible plugin hooks

### DIFF
--- a/internal/openai/openai.go
+++ b/internal/openai/openai.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/glo0ml34f/grimux/internal/input"
+	"github.com/glo0ml34f/grimux/internal/plugin"
 )
 
 const defaultAPIURL = "https://api.openai.com/v1/chat/completions"
@@ -105,6 +106,7 @@ type chatResponse struct {
 
 // SendPrompt sends the given text as a user message and returns the assistant's reply.
 func (c *Client) SendPrompt(prompt string) (string, error) {
+	prompt = plugin.GetManager().RunHook("before_openai", "", prompt)
 	reqBody := chatRequest{
 		Model:    ModelName,
 		Messages: []chatMessage{{Role: "user", Content: prompt}},
@@ -138,5 +140,7 @@ func (c *Client) SendPrompt(prompt string) (string, error) {
 	if len(cr.Choices) == 0 {
 		return "", fmt.Errorf("openai: no choices in response")
 	}
-	return cr.Choices[0].Message.Content, nil
+	reply := cr.Choices[0].Message.Content
+	reply = plugin.GetManager().RunHook("after_openai", "", reply)
+	return reply, nil
 }

--- a/internal/openai/openai_test.go
+++ b/internal/openai/openai_test.go
@@ -1,10 +1,15 @@
 package openai
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/glo0ml34f/grimux/internal/plugin"
 )
 
 func TestSendPrompt(t *testing.T) {
@@ -36,4 +41,52 @@ func TestSetModelName(t *testing.T) {
 		t.Fatalf("model not set")
 	}
 	SetModelName(old)
+}
+func TestOpenAIHooks(t *testing.T) {
+	var received string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		var req chatRequest
+		_ = json.Unmarshal(b, &req)
+		received = req.Messages[0].Content
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices": [{"message": {"content": "resp"}}]}`))
+	}))
+	defer srv.Close()
+	_ = os.Setenv("OPENAI_API_URL", srv.URL)
+	_ = os.Setenv("OPENAI_API_KEY", "test")
+	plugin.GetManager().Shutdown()
+	luaCode := `
+function init(h)
+  local info = {name="hooker", grimux="0.1.0", version="0.1.0"}
+  local json = '{"name":"hooker","grimux":"0.1.0","version":"0.1.0"}'
+  plugin.register(h, json)
+  plugin.hook(h, "before_openai", function(buf,val) return val .. " mod" end)
+  plugin.hook(h, "after_openai", function(buf,val) return val .. "!" end)
+end
+`
+	dir := t.TempDir()
+	luaFile := filepath.Join(dir, "plug.lua")
+	if err := os.WriteFile(luaFile, []byte(luaCode), 0o600); err != nil {
+		t.Fatalf("write lua: %v", err)
+	}
+	plugin.SetPrintHandler(func(*plugin.Plugin, string) {})
+	if _, err := plugin.GetManager().Load(luaFile); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	c.HTTPClient = srv.Client()
+	reply, err := c.SendPrompt("hi")
+	if err != nil {
+		t.Fatalf("SendPrompt: %v", err)
+	}
+	if received != "hi mod" {
+		t.Fatalf("prompt=%s", received)
+	}
+	if reply != "resp!" {
+		t.Fatalf("reply=%s", reply)
+	}
 }

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -195,6 +195,7 @@ func (m *Manager) Load(path string) (*Plugin, error) {
 			}
 			val, ok := readBufFn(pluginBufferName(p.Info.Name, name))
 			if ok {
+				val = m.RunHook("after_read", pluginBufferName(p.Info.Name, name), val)
 				L.Push(lua.LString(val))
 			} else {
 				L.Push(lua.LNil)
@@ -209,6 +210,7 @@ func (m *Manager) Load(path string) (*Plugin, error) {
 			}
 			name := L.CheckString(2)
 			data := L.CheckString(3)
+			data = m.RunHook("before_write", pluginBufferName(p.Info.Name, name), data)
 			if writeBufFn != nil {
 				writeBufFn(pluginBufferName(p.Info.Name, name), data)
 			}
@@ -258,6 +260,9 @@ func (m *Manager) Load(path string) (*Plugin, error) {
 			}
 			if !exists {
 				p.hooks[hookName] = append(p.hooks[hookName], cb)
+				if m.printFn != nil && !m.mute[p.Info.Name] {
+					m.printFn(p, fmt.Sprintf("hook registered: %s", hookName))
+				}
 			}
 			L.Push(lua.LString(p.Handle))
 			return 1

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -229,6 +229,7 @@ func flushPluginMsgs() {
 var respSep = strings.Repeat("─", 40)
 
 func renderMarkdown(md string) {
+	md = plugin.GetManager().RunHook("before_markdown", "", md)
 	out, err := glamour.Render(md, "dark")
 	if err != nil {
 		captureOut(md, true)
@@ -437,6 +438,7 @@ func writeBuffer(name, data string) {
 		tmux.SendKeys(name, data)
 		return
 	}
+	data = plugin.GetManager().RunHook("before_write", name, data)
 	buffers[name] = data
 }
 
@@ -1063,6 +1065,7 @@ func saveSession() {
 }
 
 func handleCommand(cmd string) bool {
+	cmd = plugin.GetManager().RunHook("before_command", "", cmd)
 	fields := strings.Fields(cmd)
 	for i := range fields {
 		fields[i] = sanitize(fields[i])


### PR DESCRIPTION
## Summary
- add plugin message when hooks are registered
- run hooks for buffer writes and reads from plugins
- support hooks for command parsing, markdown rendering and OpenAI prompt/response
- provide tests for new hooks

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685741e2576083299d666255ffa0213d