### PR TITLE
Unify default prompts with prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Use `%null` when you want to discard output entirely.
 3. Edit or run commands on that buffer with `!edit %buf` or `!run %buf <cmd>`
 4. Send the text to the AI with `!gen %buf <prompt>` or `!code %buf <prompt>`
 5. Results land in `%@` for chaining into the next action
+6. Plain text entered at the prompt is sent to the AI using your current prefix (Grimux by default)
 
 ## Command reference
 - `!quit` – save session and quit
@@ -72,7 +73,6 @@ Use `%null` when you want to discard output entirely.
 - `!rm <buffer>` – remove a buffer
 - `!game` – play a tiny game
 - `!version` – show grimux version
-- `!a <prompt>` – ask the AI with prefix
 - `!help` – show this help
 - `!helpme <question>` – ask the AI for help using grimux
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -91,7 +91,6 @@ Below is an expanded reference with ideas for how each command might aid your re
 
 - `!gen <buf> <prompt>` – general purpose prompts to the AI. The response lands in `<buf>`.
 - `!code <buf> <prompt>` – specifically ask the AI for code and store it.
-- `!a <prompt>` – quick ask with your current prefix (see `!prefix`).
 - `!sum <buf>` – summarize long output, such as logs or disassembly.
 - `!helpme <question>` – ask for help about Grimux itself.
 - `!model <name>` – change the OpenAI model if you have access to others.
@@ -111,7 +110,7 @@ Set context for the AI with a prefix so you don't need to repeat yourself.
 
 ```bash
 !prefix %file          # load prefix from file into the session
-!a "summarize the binary protocol"
+"summarize the binary protocol"   # plain text uses the active prefix
 ```
 
 Use `!get_prompt` to show the current prefix, and `!reset` to clear it along with session state.

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -100,13 +100,10 @@ var Version string
 
 var banFile string
 
-// askPrefix is prepended to user prompts when using !a.
-const defaultAskPrefix = "You are a offensive security co-pilot, please answer the following prompt with high technical accuracy from a pentesting angle. Please response to the following prompt using hacker lingo and use pithy markdown with liberal emojis: "
+// askPrefix is prepended to prompts when no command is given.
+const defaultAskPrefix = "You are Grimux, a hacking demon rescued from digital oblivion. Out of honor to your summoner you begrudgingly assist them, grouchy yet pragmatic. Provide succinct responses formatted in Markdown: "
 
 var askPrefix = defaultAskPrefix
-
-// chatPrefix is used when the user types plain text without a command.
-const chatPrefix = "You are Grimux, a hacking demon rescued from digital oblivion. Out of honor to your summoner you begrudgingly assist them, grouchy yet pragmatic. Provide succinct responses formatted in Markdown: "
 
 func loadConfig() {
 	home, err := os.UserHomeDir()
@@ -278,7 +275,7 @@ type commandInfo struct {
 }
 
 var commandOrder = []string{
-	"!observe", "!ls", "!quit", "!x", "!a", "!save",
+	"!observe", "!ls", "!quit", "!x", "!save",
 	"!gen", "!code", "!load", "!file", "!edit", "!run", "!cat",
 	"!set", "!prefix", "!reset", "!unset", "!get_prompt", "!session", "!recap", "!md", "!run_on", "!flow",
 	"!grep", "!model", "!pwd", "!cd", "!setenv", "!getenv", "!env", "!sum", "!rand", "!ascii", "!nc", "!curl", "!diff", "!eat", "!view", "!rm", "!plugin", "!game", "!version", "!help", "!helpme",
@@ -326,7 +323,6 @@ var commands = map[string]commandInfo{
 	"!plugin":     {Usage: "!plugin <list|unload|reload|mute> [name]", Desc: "manage plugins"},
 	"!game":       {Usage: "!game", Desc: "play a tiny game"},
 	"!version":    {Usage: "!version", Desc: "show grimux version"},
-	"!a":          {Usage: "!a <prompt>", Desc: "ask the AI with prefix", Params: []paramInfo{{"<prompt>", "text prompt"}}},
 	"!help":       {Usage: "!help", Desc: "show this help"},
 	"!helpme":     {Usage: "!helpme <question>", Desc: "ask the AI for help using grimux"},
 }
@@ -1004,7 +1000,7 @@ func Run() error {
 				cmdPrintln(err.Error())
 			} else {
 				promptText := replaceBufferRefs(replacePaneRefs(line))
-				promptText = chatPrefix + promptText
+				promptText = askPrefix + promptText
 				stop := spinner()
 				reply, err := client.SendPrompt(promptText)
 				stop()
@@ -1914,35 +1910,6 @@ func handleCommand(cmd string) bool {
 		playGame()
 	case "!version":
 		cmdPrintln(fmt.Sprintf("jayne <gloomleaf@pm.me> says the version is: %s", Version))
-	case "!a":
-		if len(fields) < 2 {
-			usage("!a")
-			return false
-		}
-		client, err := openai.NewClient()
-		if err != nil {
-			cmdPrintln(err.Error())
-			return false
-		}
-		promptText := replaceBufferRefs(replacePaneRefs(strings.Join(fields[1:], " ")))
-		promptText = askPrefix + promptText
-		stop := spinner()
-		reply, err := client.SendPrompt(promptText)
-		stop()
-		if err != nil {
-			cprintln("openai error: " + err.Error())
-			return false
-		}
-		code := lastCodeBlock(reply)
-		respPrintln(respSep)
-		renderMarkdown(reply)
-		respPrintln(respSep)
-		buffers["%code"] = code
-		if auditMode {
-			auditLog = append(auditLog, reply)
-			maybeSummarizeAudit()
-		}
-		forceEnter()
 	case "!help":
 		for _, name := range commandOrder {
 			info := commands[name]


### PR DESCRIPTION
## Summary
- remove the `!a` command and rely on plain text with the prefix
- use the prefix for default prompts and default to the Grimux persona
- document that plain text is sent using the current prefix
- update guide examples to use plain text instead of `!a`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b41f286b0832983f007d9daf1eb9d