### PR TITLE
Improve plugin arg handling and GitHub issue plugin

### DIFF
--- a/plugins/github_issue.lua
+++ b/plugins/github_issue.lua
@@ -8,14 +8,28 @@ end
 
 function create(h, repo, title, body, token, host)
   if not repo or repo == "" then
-    repo = plugin.prompt(h, "repo", "repository (owner/repo): ")
+    repo = plugin.read(h, "repo")
+    if not repo or repo == "" then
+      repo = plugin.prompt(h, "repo", "repository (owner/repo): ")
+    end
   end
+  plugin.write(h, "repo", repo)
+
   if not title or title == "" then
-    title = plugin.prompt(h, "title", "issue title: ")
+    title = plugin.read(h, "title")
+    if not title or title == "" then
+      title = plugin.prompt(h, "title", "issue title: ")
+    end
   end
+  plugin.write(h, "title", title)
+
   if not body or body == "" then
-    body = plugin.prompt(h, "body", "issue body: ")
+    body = plugin.read(h, "body")
+    if not body or body == "" then
+      body = plugin.prompt(h, "body", "issue body: ")
+    end
   end
+  plugin.write(h, "body", body)
 
   if not host or host == "" then
     host = plugin.read(h, "host")
@@ -39,7 +53,7 @@ function create(h, repo, title, body, token, host)
 
   local url = plugin.format(h, "https://%s/repos/%s/issues", host, repo)
   local opts = plugin.format(h,
-    '{"json":{"title":"%s","body":"%s"},"headers":{"Authorization":"token %s","User-Agent":"grimux"}}',
+    '{"json":{"title":%q,"body":%q},"headers":{"Authorization":"token %s","User-Agent":"grimux"}}',
     title, body, token)
   local resp, status = plugin.http(h, "POST", url, opts)
   if status == 201 then

--- a/plugins/github_issue.lua
+++ b/plugins/github_issue.lua
@@ -6,7 +6,7 @@ function init(h)
   plugin.print(h, "github_issue plugin loaded")
 end
 
-function create(h, repo, title, body, token)
+function create(h, repo, title, body, token, host)
   if not repo or repo == "" then
     repo = plugin.prompt(h, "repo", "repository (owner/repo): ")
   end
@@ -16,6 +16,14 @@ function create(h, repo, title, body, token)
   if not body or body == "" then
     body = plugin.prompt(h, "body", "issue body: ")
   end
+
+  if not host or host == "" then
+    host = plugin.read(h, "host")
+    if not host or host == "" then
+      host = "api.github.com"
+    end
+  end
+  plugin.write(h, "host", host)
 
   -- Load the token from the plugin buffer if available.
   if (not token or token == "") then
@@ -29,7 +37,7 @@ function create(h, repo, title, body, token)
   -- Save the token for next time.
   plugin.write(h, "token", token)
 
-  local url = plugin.format(h, "https://api.github.com/repos/%s/issues", repo)
+  local url = plugin.format(h, "https://%s/repos/%s/issues", host, repo)
   local opts = plugin.format(h,
     '{"json":{"title":"%s","body":"%s"},"headers":{"Authorization":"token %s","User-Agent":"grimux"}}',
     title, body, token)


### PR DESCRIPTION
## Summary
- allow plugin command arguments to reference buffers
- add regression test for buffer arg expansion
- allow overriding GitHub API host in plugin

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b6f356b1c83299cb92cd1988035b9