### PR TITLE
Add tmux buffer integration

### DIFF
--- a/internal/input/input.go
+++ b/internal/input/input.go
@@ -29,8 +29,9 @@ func ReadPasswordPrompt(prompt string) (string, error) {
 // ReadLinePrompt reads a line showing the given prompt.
 func ReadLinePrompt(prompt string) (string, error) {
 	if rl != nil {
-		fmt.Fprint(rl.Stdout(), prompt)
-		return rl.Readline()
+		rl.SetPrompt(prompt)
+		line, err := rl.Readline()
+		return line, err
 	}
 	fmt.Fprint(os.Stdout, prompt)
 	return ReadLine()

--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -744,6 +744,8 @@ func loadSessionFromBuffer() {
 }
 
 func updateSessionBuffer() {
+	// Apply any modifications from the %session buffer before writing a new snapshot.
+	loadSessionFromBuffer()
 	s := sessionSnapshot()
 	if b, err := json.MarshalIndent(s, "", "  "); err == nil {
 		buffers["%session"] = string(b)

--- a/internal/repl/repl_test.go
+++ b/internal/repl/repl_test.go
@@ -2,6 +2,9 @@ package repl
 
 import (
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -64,5 +67,38 @@ func TestNullBuffer(t *testing.T) {
 	writeBuffer("%null", "ignored")
 	if val, ok := readBuffer("%null"); !ok || val != "" {
 		t.Fatal("%null should always be empty")
+	}
+}
+
+// startFakeTmux creates a fake tmux binary for testing.
+func startFakeTmux(t *testing.T, output string) (sock, argsFile string, cleanup func()) {
+	t.Helper()
+	tmp := t.TempDir()
+	sock = filepath.Join(tmp, "tmux.sock")
+	if err := os.WriteFile(sock, nil, 0600); err != nil {
+		t.Fatalf("create fake socket: %v", err)
+	}
+	argsFile = filepath.Join(tmp, "args")
+	script := fmt.Sprintf("#!/bin/sh\necho \"$@\" > %s\ncat <<'EOF'\n%sEOF\n", argsFile, output)
+	bin := filepath.Join(tmp, "tmux")
+	if err := os.WriteFile(bin, []byte(script), 0755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+	oldPath := os.Getenv("PATH")
+	os.Setenv("PATH", tmp+string(os.PathListSeparator)+oldPath)
+	cleanup = func() { os.Setenv("PATH", oldPath) }
+	return sock, argsFile, cleanup
+}
+
+func TestIsTmuxBuffer(t *testing.T) {
+	sock, _, cleanup := startFakeTmux(t, "foo\nbar\n")
+	defer cleanup()
+	os.Setenv("TMUX", sock+",s")
+
+	if !isTmuxBuffer("%foo") {
+		t.Fatalf("%%foo should be detected as tmux buffer")
+	}
+	if isTmuxBuffer("%baz") {
+		t.Fatalf("%%baz should not be detected as tmux buffer")
 	}
 }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -172,7 +172,7 @@ func SetBuffer(name, data string) error {
 		return errors.New("TMUX environment variable is not set")
 	}
 	socket := strings.Split(tmuxEnv, ",")[0]
-	args := []string{"-S", socket, "set-buffer"}
+	args := []string{"-S", socket, "load-buffer"}
 	if name != "" {
 		args = append(args, "-b", name)
 	}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -106,3 +106,58 @@ func ListPaneIDs() ([]string, error) {
 	out := strings.Fields(buf.String())
 	return out, nil
 }
+
+// ListBuffers returns the names of all tmux buffers.
+func ListBuffers() ([]string, error) {
+	tmuxEnv := os.Getenv("TMUX")
+	if tmuxEnv == "" {
+		return nil, errors.New("TMUX environment variable is not set")
+	}
+	socket := strings.Split(tmuxEnv, ",")[0]
+	args := []string{"-S", socket, "list-buffers", "-F", "#{buffer_name}"}
+	cmd := exec.Command("tmux", args...)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("tmux command: %w", err)
+	}
+	out := strings.Fields(buf.String())
+	return out, nil
+}
+
+// ShowBuffer returns the contents of the specified tmux buffer.
+func ShowBuffer(name string) (string, error) {
+	tmuxEnv := os.Getenv("TMUX")
+	if tmuxEnv == "" {
+		return "", errors.New("TMUX environment variable is not set")
+	}
+	socket := strings.Split(tmuxEnv, ",")[0]
+	args := []string{"-S", socket, "show-buffer"}
+	if name != "" {
+		args = append(args, "-b", name)
+	}
+	cmd := exec.Command("tmux", args...)
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("tmux command: %w", err)
+	}
+	return buf.String(), nil
+}
+
+// SetBuffer stores data into a named tmux buffer.
+func SetBuffer(name, data string) error {
+	tmuxEnv := os.Getenv("TMUX")
+	if tmuxEnv == "" {
+		return errors.New("TMUX environment variable is not set")
+	}
+	socket := strings.Split(tmuxEnv, ",")[0]
+	args := []string{"-S", socket, "set-buffer"}
+	if name != "" {
+		args = append(args, "-b", name)
+	}
+	args = append(args, "-")
+	cmd := exec.Command("tmux", args...)
+	cmd.Stdin = strings.NewReader(data)
+	return cmd.Run()
+}

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -154,7 +154,7 @@ func TestSetBuffer(t *testing.T) {
 
 	b, _ := os.ReadFile(argsFile)
 	args := string(bytes.TrimSpace(b))
-	expected := fmt.Sprintf("-S %s set-buffer -b foo -", sock)
+	expected := fmt.Sprintf("-S %s load-buffer -b foo -", sock)
 	if args != expected {
 		t.Fatalf("unexpected args: %q", args)
 	}

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -102,7 +102,7 @@ func TestSendKeys(t *testing.T) {
 }
 
 func TestListBuffers(t *testing.T) {
-	sock, argsFile, cleanup := startFakeTmux(t, "buf1\nbuf2\n")
+	sock, argsFile, cleanup := startFakeTmux(t, "buf1|5\nbuf2|3\n")
 	defer cleanup()
 	os.Setenv("TMUX", sock+",s")
 
@@ -110,13 +110,13 @@ func TestListBuffers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListBuffers: %v", err)
 	}
-	if len(bufs) != 2 || bufs[0] != "buf1" || bufs[1] != "buf2" {
+	if len(bufs) != 2 || bufs[0].Name != "buf1" || bufs[0].Size != 5 || bufs[1].Name != "buf2" || bufs[1].Size != 3 {
 		t.Fatalf("unexpected buffers: %v", bufs)
 	}
 
 	b, _ := os.ReadFile(argsFile)
 	args := string(bytes.TrimSpace(b))
-	expected := fmt.Sprintf("-S %s list-buffers -F #{buffer_name}", sock)
+	expected := fmt.Sprintf("-S %s list-buffers -F #{buffer_name}|#{buffer_size}", sock)
 	if args != expected {
 		t.Fatalf("unexpected args: %q", args)
 	}

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -100,3 +100,62 @@ func TestSendKeys(t *testing.T) {
 		t.Fatalf("unexpected args: %q", args)
 	}
 }
+
+func TestListBuffers(t *testing.T) {
+	sock, argsFile, cleanup := startFakeTmux(t, "buf1\nbuf2\n")
+	defer cleanup()
+	os.Setenv("TMUX", sock+",s")
+
+	bufs, err := ListBuffers()
+	if err != nil {
+		t.Fatalf("ListBuffers: %v", err)
+	}
+	if len(bufs) != 2 || bufs[0] != "buf1" || bufs[1] != "buf2" {
+		t.Fatalf("unexpected buffers: %v", bufs)
+	}
+
+	b, _ := os.ReadFile(argsFile)
+	args := string(bytes.TrimSpace(b))
+	expected := fmt.Sprintf("-S %s list-buffers -F #{buffer_name}", sock)
+	if args != expected {
+		t.Fatalf("unexpected args: %q", args)
+	}
+}
+
+func TestShowBuffer(t *testing.T) {
+	sock, argsFile, cleanup := startFakeTmux(t, "hello\n")
+	defer cleanup()
+	os.Setenv("TMUX", sock+",s")
+
+	out, err := ShowBuffer("foo")
+	if err != nil {
+		t.Fatalf("ShowBuffer: %v", err)
+	}
+	if out != "hello\n" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+
+	b, _ := os.ReadFile(argsFile)
+	args := string(bytes.TrimSpace(b))
+	expected := fmt.Sprintf("-S %s show-buffer -b foo", sock)
+	if args != expected {
+		t.Fatalf("unexpected args: %q", args)
+	}
+}
+
+func TestSetBuffer(t *testing.T) {
+	sock, argsFile, cleanup := startFakeTmux(t, "")
+	defer cleanup()
+	os.Setenv("TMUX", sock+",s")
+
+	if err := SetBuffer("foo", "data"); err != nil {
+		t.Fatalf("SetBuffer: %v", err)
+	}
+
+	b, _ := os.ReadFile(argsFile)
+	args := string(bytes.TrimSpace(b))
+	expected := fmt.Sprintf("-S %s set-buffer -b foo -", sock)
+	if args != expected {
+		t.Fatalf("unexpected args: %q", args)
+	}
+}


### PR DESCRIPTION
## Summary
- support tmux buffer operations in `tmux` package
- expose tmux buffer color and parsing in REPL
- list tmux buffers with `!ls`
- read/write named tmux buffers via `%[name]`
- add tests for tmux buffer helpers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685b7c05512c8329836f34ec9e8e9d49