### PR TITLE
Add new buffer utilities and model prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Use `%null` when you want to discard output entirely.
 - `!sum <buffer>` – summarize buffer with LLM
 - `!rand <min> <max> <buffer>` – store random number
 - `!ascii <buffer>` – gothic ascii art of first 5 words
+- `!pipe <buffer> <cmd> [args]` – pipe buffer to a command
+- `!encode <buffer> <encoding>` – encode a buffer (base64, urlsafe, uri, hex)
+- `!hash <buffer> <algo>` – hash a buffer (md5, sha1, sha256, sha512)
 - `!socat <buffer> <args>` – pipe buffer to socat
 - `!curl <url> [buffer] [headers]` – HTTP GET and store body with optional headers
 - `!diff <left> <right> [buffer]` – diff two buffers or files
@@ -84,6 +87,7 @@ Use `%null` when you want to discard output entirely.
 - `!version` – show grimux version
 - `!help` – show this help
 - `!helpme <question>` – ask the AI for help using grimux
+- `!idk <prompt>` – get strategic encouragement
 
 Every command except `!game` writes its output to `%@`. Use `%name` references in
 any command to insert buffer contents or `{%1}` to embed a pane capture.
@@ -99,6 +103,7 @@ any command to insert buffer contents or `{%1}` to embed a pane capture.
 ## Environment
 - `OPENAI_API_KEY` – API key used by AI commands
 - `OPENAI_API_URL` – override the OpenAI endpoint
+- `OPENAI_MODEL` – preferred OpenAI model (prompted if unset)
 - `$EDITOR` – editor for `!edit` (defaults to `vim`)
 - `$VIEWER` – viewer for `!view` (defaults to `batcat`)
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -82,6 +82,7 @@ Below is an expanded reference with ideas for how each command might aid your re
 
 - `!run [buf] <cmd>` – execute a shell command, optionally piping in a buffer. Use this to compile code or run enumeration scripts.
 - `!run_on <buf> <pane> <cmd>` – run a command on another pane and capture its output into `<buf>`.
+- `!pipe <buf> <cmd> [args]` – pipe a buffer to an arbitrary command.
 - `!socat <buf> <args>` – pipe a buffer to socat. Convenient for sending crafted payloads or bridging protocols.
 - `!curl <url> [buf] [hdrs]` – fetch a URL into a buffer, optionally using headers from `hdrs`.
 - `!diff <a> <b> [buf]` – show a colorized diff between buffers or files.
@@ -94,12 +95,15 @@ Below is an expanded reference with ideas for how each command might aid your re
 - `!sum <buf>` – summarize long output, such as logs or disassembly.
 - `!helpme <question>` – ask for help about Grimux itself.
 - `!model <name>` – change the OpenAI model if you have access to others.
+- `!idk <prompt>` – get strategic encouragement when you're stuck.
 
 ### Environment and Utility
 
 - `!setenv <var> <buf>` / `!getenv <var> <buf>` – bridge environment variables and buffers.
 - `!rand <min> <max> <buf>` – generate a random integer; useful for filenames or tokens.
 - `!ascii <buf>` – render gothic ASCII art of the first few words for flair.
+- `!encode <buf> <encoding>` – encode a buffer (base64, urlsafe, uri, hex).
+- `!hash <buf> <algo>` – compute a hash of a buffer (md5, sha1, sha256, sha512).
 - `!view <buf>` – open a viewer (default `batcat`) for nicer reading of long text.
 - `!version` – print Grimux's version.
 - `!game` – take a short break with a mini‑game; high scores persist in memory until you save.

--- a/internal/openai/openai.go
+++ b/internal/openai/openai.go
@@ -17,10 +17,9 @@ const defaultAPIURL = "https://api.openai.com/v1/chat/completions"
 // defaultModelName is used when the user has not configured a model.
 const defaultModelName = "gpt-4o"
 
-// ModelName controls which OpenAI model is used for requests.
-// ModelName controls which OpenAI model is used for requests. It defaults to
-// defaultModelName but can be overridden by the user or session data.
-var ModelName = defaultModelName
+// ModelName controls which OpenAI model is used for requests. It is empty until
+// configured via the environment, session data, or user prompt.
+var ModelName string
 
 var sessionAPIURL string
 
@@ -97,6 +96,9 @@ func NewClient() (*Client, error) {
 	}
 
 	if ModelName == "" {
+		ModelName = os.Getenv("OPENAI_MODEL")
+	}
+	if ModelName == "" {
 		prompt := fmt.Sprintf("OpenAI model [%s]: ", defaultModelName)
 		line, err := input.ReadLinePrompt(prompt)
 		if err != nil {
@@ -108,6 +110,9 @@ func NewClient() (*Client, error) {
 		} else {
 			ModelName = defaultModelName
 		}
+	}
+	if ModelName == "" {
+		ModelName = defaultModelName
 	}
 
 	return &Client{APIKey: key, APIURL: url, HTTPClient: http.DefaultClient}, nil

--- a/internal/openai/openai_test.go
+++ b/internal/openai/openai_test.go
@@ -20,6 +20,8 @@ func TestSendPrompt(t *testing.T) {
 	defer srv.Close()
 	_ = os.Setenv("OPENAI_API_URL", srv.URL)
 	_ = os.Setenv("OPENAI_API_KEY", "test")
+	SetModelName(defaultModelName)
+	SetModelName(defaultModelName)
 	c, err := NewClient()
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
@@ -55,6 +57,7 @@ func TestOpenAIHooks(t *testing.T) {
 	defer srv.Close()
 	_ = os.Setenv("OPENAI_API_URL", srv.URL)
 	_ = os.Setenv("OPENAI_API_KEY", "test")
+	SetModelName(defaultModelName)
 	plugin.GetManager().Shutdown()
 	luaCode := `
 function init(h)

--- a/internal/repl/completer.go
+++ b/internal/repl/completer.go
@@ -29,6 +29,13 @@ func (c *autoCompleter) Do(line []rune, pos int) ([][]rune, int) {
 				suggestions = append(suggestions, id[len(prefix):])
 			}
 		}
+		bufs, _ := tmux.ListBuffers()
+		for _, b := range bufs {
+			name := "%" + b.Name
+			if strings.HasPrefix(name, prefix) {
+				suggestions = append(suggestions, name[len(prefix):])
+			}
+		}
 		matches, _ := filepath.Glob(prefix + "*")
 		for _, m := range matches {
 			if strings.HasPrefix(m, prefix) {


### PR DESCRIPTION
## Summary
- prompt for OpenAI model if unset using OPENAI_MODEL or interactively
- autocomplete tmux buffers
- add `!pipe`, `!encode`, `!hash`, and `!idk` commands
- expose `plugin.pipe` to Lua plugins
- document new commands and OPENAI_MODEL env var

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685e1c53908c8329b5df4f79ce1d9d46