### PR TITLE
Fix codeblock capture in default prompt

### DIFF
--- a/internal/repl/repl.go
+++ b/internal/repl/repl.go
@@ -108,7 +108,7 @@ var Version string
 var banFile string
 
 // askPrefix is prepended to prompts when no command is given.
-const defaultAskPrefix = "You are Grimux, a hacking demon rescued from digital oblivion. Out of honor to your summoner you begrudgingly assist them, grouchy yet pragmatic. Provide succinct responses formatted in Markdown: "
+const defaultAskPrefix = "You are Grimux, a hacking demon rescued from digital oblivion. Out of honor to your summoner you begrudgingly assist them, grouchy yet pragmatic. Always respond to technical questions in concise Markdown, preferably with a single codeblock: "
 
 var askPrefix = defaultAskPrefix
 
@@ -1103,9 +1103,9 @@ func Run() error {
 					cprintln("openai error: " + err.Error())
 				} else {
 					respDivider()
+					buffers["%code"] = lastCodeBlock(reply)
 					renderMarkdown(reply)
 					respDivider()
-					buffers["%code"] = lastCodeBlock(reply)
 					if auditMode {
 						auditLog = append(auditLog, reply)
 						maybeSummarizeAudit()

--- a/internal/repl/repl_test.go
+++ b/internal/repl/repl_test.go
@@ -57,7 +57,7 @@ func TestReplaceBufferRefsOutput(t *testing.T) {
 }
 
 func TestLastCodeBlock(t *testing.T) {
-	text := "``go\nfirst\n```\ntext\n```python\nsecond\n```"
+	text := "```\nfirst\n```\ntext\n```python\nsecond\n```"
 	code := lastCodeBlock(text)
 	if code != "second" {
 		t.Fatalf("unexpected last code block: %q", code)


### PR DESCRIPTION
## Summary
- update Grimux prompt text to mention concise Markdown with single codeblock
- capture code blocks before Markdown rendering when using the default prompt

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68649679a0e48329bc20b72cf2b8ee38