### PR TITLE
Implement !new command and add unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Use `%null` when you want to discard output entirely.
 - `!set <buffer> <text>` – store text in buffer
 - `!prefix <buffer|file>` – set prefix from buffer or file
 - `!reset` – reset session and prefix
+- `!new` – clear chat context to free tokens
 - `!unset <buffer>` – clear buffer
 - `%null` – special buffer that discards all writes and always reads empty
 - `!get_prompt` – show current prefix

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -118,6 +118,7 @@ Set context for the AI with a prefix so you don't need to repeat yourself.
 ```
 
 Use `!get_prompt` to show the current prefix, and `!reset` to clear it along with session state.
+Use `!new` when responses start hitting token limits to erase prior conversation context.
 
 ## Tips and Tricks
 

--- a/internal/repl/repl_test.go
+++ b/internal/repl/repl_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -68,6 +69,44 @@ func TestNullBuffer(t *testing.T) {
 	writeBuffer("%null", "ignored")
 	if val, ok := readBuffer("%null"); !ok || val != "" {
 		t.Fatal("%null should always be empty")
+	}
+}
+
+func TestHandleCommandBasic(t *testing.T) {
+	// test !set, !prefix, !get_prompt, !unset and !new
+	chatCtx = []byte("old context")
+
+	if handleCommand("!set %foo bar") {
+		t.Fatalf("!set should not request exit")
+	}
+	if val, ok := buffers["%foo"]; !ok || val != "bar" {
+		t.Fatalf("buffer not set: %v %q", ok, val)
+	}
+
+	if handleCommand("!prefix %foo") {
+		t.Fatalf("!prefix should not request exit")
+	}
+	if askPrefix != "bar" {
+		t.Fatalf("prefix not updated: %q", askPrefix)
+	}
+
+	handleCommand("!get_prompt")
+	if !strings.Contains(buffers["%@"], "bar") {
+		t.Fatalf("!get_prompt output not captured")
+	}
+
+	if handleCommand("!unset %foo") {
+		t.Fatalf("!unset should not request exit")
+	}
+	if _, ok := buffers["%foo"]; ok {
+		t.Fatalf("buffer should be removed")
+	}
+
+	if handleCommand("!new") {
+		t.Fatalf("!new should not request exit")
+	}
+	if len(chatCtx) != 0 {
+		t.Fatalf("chat context not cleared")
 	}
 }
 


### PR DESCRIPTION
## Summary
- implement `!new` command to clear chat context
- document `!new` in README and guide
- comment chat context code
- add unit tests including `!new`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6864a6b5d4888329bd257a8708e3cc46